### PR TITLE
Add extension method for Localizations

### DIFF
--- a/lib/l10n/ext.dart
+++ b/lib/l10n/ext.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+extension AppLocalizationsExt on BuildContext {
+  AppLocalizations get l10n => AppLocalizations.of(this)!;
+}

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -1,5 +1,7 @@
 {
   "@@locale" : "cs",
   "continue_info": "Pokračovat",
-  "@continue_info": {}
+  "@continue_info": {},
+  "carousel_content_experience_relief": "Zažiješ úlevu, že jsi nic nezanedbal/a.",
+  "@carousel_content_experience_relief": {}
 }

--- a/lib/ui/screens/onboarding/carousel/carousel_third.dart
+++ b/lib/ui/screens/onboarding/carousel/carousel_third.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:loono/ui/widgets/carousel_content_widget.dart';
+import 'package:loono/l10n/ext.dart';
 
 class OnboardingThirdCarouselScreen extends StatelessWidget {
   @override
@@ -10,7 +11,7 @@ class OnboardingThirdCarouselScreen extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 20.0),
           child: CarouselContentWidget(
-            text: 'Zažiješ úlevu, že jsi nic nezanedbal/a.',
+            text: context.l10n.carousel_content_experience_relief,
             image: Row(
               children: [
                 Image.asset('assets/images/carousel-image-3.png'),


### PR DESCRIPTION
I personally think that calling `AppLocalizations.of(context)!` (29 chars vs 12) every time is a bit unnecessarily long, the only downside with using extensions is that they must be manually imported..