### PR TITLE
Onboarding carousel updates

### DIFF
--- a/lib/ui/screens/onboarding/carousel/carousel.dart
+++ b/lib/ui/screens/onboarding/carousel/carousel.dart
@@ -19,9 +19,13 @@ class _OnboardingCarouselScreenState extends State<OnboardingCarouselScreen> {
 
   int get currentPageIndex => pageController.hasClients ? pageController.page?.round() ?? 0 : 0;
 
-  void jumpToPrevPage() => pageController.jumpToPage(currentPageIndex - 1);
+  bool get canTransitionToPrevStory => currentPageIndex > 0;
 
-  void jumpToNextPage() => pageController.jumpToPage(currentPageIndex + 1);
+  bool get canTransitionToNextStory => currentPageIndex < stories.length - 1;
+
+  void jumpToPrevStory() => pageController.jumpToPage(currentPageIndex - 1);
+
+  void jumpToNextStory() => pageController.jumpToPage(currentPageIndex + 1);
 
   final stories = const <StoryPage>[
     StoryPage.dark(content: IntroVideo(), duration: Duration(seconds: 13)),
@@ -57,9 +61,10 @@ class _OnboardingCarouselScreenState extends State<OnboardingCarouselScreen> {
             currentIndex: currentPageIndex,
             currentDuration: currentStory.duration,
             currentStoryPageBackground: currentStory.storyPageBackground,
+            onStoryFinish: canTransitionToNextStory ? jumpToNextStory : null,
           ),
-          if (currentPageIndex > 0) TapArea.leftSide(onTap: jumpToPrevPage),
-          if (currentPageIndex < stories.length - 1) TapArea.rightSide(onTap: jumpToNextPage),
+          if (canTransitionToPrevStory) TapArea.leftSide(onTap: jumpToPrevStory),
+          if (canTransitionToNextStory) TapArea.rightSide(onTap: jumpToNextStory),
           if (currentStory.hasInteractiveContent) currentStory.interactiveContent!,
         ],
       ),

--- a/lib/ui/widgets/onboarding/carousel/indicator.dart
+++ b/lib/ui/widgets/onboarding/carousel/indicator.dart
@@ -30,6 +30,7 @@ class Indicator extends StatefulWidget {
     required this.maxWidth,
     this.height = 4.0,
     required this.indicatorStyle,
+    this.onFinish,
   }) : super(key: key);
 
   final bool finished;
@@ -38,6 +39,7 @@ class Indicator extends StatefulWidget {
   final double maxWidth;
   final double height;
   final IndicatorStyle indicatorStyle;
+  final VoidCallback? onFinish;
 
   @override
   _IndicatorState createState() => _IndicatorState();
@@ -55,13 +57,18 @@ class _IndicatorState extends State<Indicator> with SingleTickerProviderStateMix
     animationController = AnimationController(
       duration: widget.duration,
       vsync: this,
-    );
+    )..addStatusListener((status) {
+        if (status == AnimationStatus.completed) {
+          widget.onFinish?.call();
+        }
+      });
     containerAnim = Tween<double>(begin: 0.0, end: widget.maxWidth).animate(animationController);
   }
 
   @override
   void didUpdateWidget(Indicator oldWidget) {
     super.didUpdateWidget(oldWidget);
+    animationController.reset();
     if (animationController.duration != widget.duration) {
       animationController.duration = widget.duration;
     }

--- a/lib/ui/widgets/onboarding/carousel/indicator_row.dart
+++ b/lib/ui/widgets/onboarding/carousel/indicator_row.dart
@@ -13,6 +13,7 @@ class IndicatorRow extends StatelessWidget {
     required this.currentDuration,
     required this.currentStoryPageBackground,
     this.padding = const EdgeInsets.only(top: 60.0, left: _sidePadding, right: _sidePadding),
+    this.onStoryFinish,
   })  : assert(numOfIndicators > 0),
         assert(currentIndex >= 0 && currentIndex < numOfIndicators),
         super(key: key);
@@ -22,6 +23,7 @@ class IndicatorRow extends StatelessWidget {
   final Duration currentDuration;
   final StoryPageBackground currentStoryPageBackground;
   final EdgeInsets padding;
+  final VoidCallback? onStoryFinish;
 
   @override
   Widget build(BuildContext context) {
@@ -43,6 +45,7 @@ class IndicatorRow extends StatelessWidget {
               indicatorStyle: currentStoryPageBackground == StoryPageBackground.light
                   ? IndicatorStyle.dark()
                   : IndicatorStyle.light(),
+              onFinish: onStoryFinish,
             );
           },
         ),

--- a/lib/ui/widgets/onboarding/carousel/story_page.dart
+++ b/lib/ui/widgets/onboarding/carousel/story_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-const _defaultDuration = Duration(seconds: 4);
+const _defaultDuration = Duration(seconds: 15);
 
 enum StoryPageBackground { dark, light }
 

--- a/lib/ui/widgets/onboarding/carousel/tap_area.dart
+++ b/lib/ui/widgets/onboarding/carousel/tap_area.dart
@@ -22,7 +22,7 @@ class TapArea extends StatelessWidget {
         behavior: HitTestBehavior.translucent,
         onTap: onTap,
         child: SizedBox(
-          width: MediaQuery.of(context).size.width / 4,
+          width: MediaQuery.of(context).size.width / 2,
           height: double.infinity,
         ),
       ),


### PR DESCRIPTION
Otakar ještě dnes doplnil nějaké info k tomu carouselu:
- defaultně má trvat story 15s
- po doběhnutí animace se má samo skočit na další story (kromě poslední)