### PR TITLE
feat: Loono podcast launcher

### DIFF
--- a/lib/ui/screens/about_health/about_health.dart
+++ b/lib/ui/screens/about_health/about_health.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:loono/utils/app_config.dart';
 import 'package:loono/utils/registry.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class AboutHealthScreen extends StatefulWidget {
   const AboutHealthScreen({Key? key}) : super(key: key);
@@ -60,6 +61,12 @@ class _AboutHealthScreenState extends State<AboutHealthScreen> {
             ),
             shouldOverrideUrlLoading: (controller, navigationAction) async {
               final uri = navigationAction.request.url!;
+
+              if (uri.host.contains('open.spotify.com')) {
+                if (await canLaunch(uri.toString())) {
+                  await launch(uri.toString());
+                }
+              }
 
               /// allow only "loono.cz" host and prevent clicks outside of loono.cz
               if (uri.host.contains('loono.cz')) {


### PR DESCRIPTION
po diskuzi na slacku s Evou Rippl, bude nový design webu O zdraví obsahovat embedované spotify podcasty. Požadované features jsou:
- inline přehrávání podcastu ve webview
- po tapnutí na "spotify" otevřít stránku podcastu na spotify. Buď spustí appku nebo fallbackne na spotify web

Tenhle PR whitelistuje hosta open.spotify.com a spouští mimo loono appku

![image](https://user-images.githubusercontent.com/19749268/152680493-aded8322-ae2d-4371-aea0-1e91166d1848.png)
