### PR TITLE
fix: onboarding routes

### DIFF
--- a/lib/ui/screens/main/pre_auth/continue_onboarding_form.dart
+++ b/lib/ui/screens/main/pre_auth/continue_onboarding_form.dart
@@ -25,8 +25,10 @@ class ContinueOnboardingFormScreen extends StatelessWidget {
                   if (AutoRouter.of(context).isRouteActive(PreAuthMainRoute().routeName)) {
                     AutoRouter.of(context).popUntilRoot();
                   }
-                  AutoRouter.of(context)
-                      .push(PreAuthMainRoute(overridenPreventionRoute: LoginRoute()));
+                  AutoRouter.of(context).replaceAll([
+                    LoginRoute(),
+                    PreAuthMainRoute(overridenPreventionRoute: LoginRoute()),
+                  ]);
                 },
               ),
               const SizedBox(height: 24),

--- a/lib/ui/screens/main/pre_auth/onboarding_form_done.dart
+++ b/lib/ui/screens/main/pre_auth/onboarding_form_done.dart
@@ -35,8 +35,10 @@ class OnboardingFormDoneScreen extends StatelessWidget {
                         if (AutoRouter.of(context).isRouteActive(PreAuthMainRoute().routeName)) {
                           AutoRouter.of(context).popUntilRoot();
                         }
-                        AutoRouter.of(context)
-                            .push(PreAuthMainRoute(overridenPreventionRoute: LoginRoute()));
+                        AutoRouter.of(context).replaceAll([
+                          LoginRoute(),
+                          PreAuthMainRoute(overridenPreventionRoute: LoginRoute()),
+                        ]);
                       },
                     ),
                     const SizedBox(height: 24),

--- a/lib/ui/screens/main/pre_auth/start_new_questionnaire.dart
+++ b/lib/ui/screens/main/pre_auth/start_new_questionnaire.dart
@@ -29,8 +29,10 @@ class StartNewQuestionnaireScreen extends StatelessWidget {
                       if (AutoRouter.of(context).isRouteActive(PreAuthMainRoute().routeName)) {
                         AutoRouter.of(context).popUntilRoot();
                       }
-                      AutoRouter.of(context)
-                          .push(PreAuthMainRoute(overridenPreventionRoute: LoginRoute()));
+                      AutoRouter.of(context).replaceAll([
+                        LoginRoute(),
+                        PreAuthMainRoute(overridenPreventionRoute: LoginRoute()),
+                      ]);
                     },
                   ),
                   const SizedBox(height: 24),

--- a/lib/ui/screens/welcome.dart
+++ b/lib/ui/screens/welcome.dart
@@ -50,8 +50,12 @@ class WelcomeScreen extends StatelessWidget {
                     TextButton(
                       onPressed: () async {
                         await _userRepository.createUserIfNotExists();
-                        await AutoRouter.of(context)
-                            .push(PreAuthMainRoute(overridenPreventionRoute: LoginRoute()));
+
+                        // ignore: unawaited_futures
+                        AutoRouter.of(context).replaceAll([
+                          LoginRoute(),
+                          PreAuthMainRoute(overridenPreventionRoute: LoginRoute()),
+                        ]);
                       },
                       child: Text(
                         context.l10n.carousel_have_account,


### PR DESCRIPTION
upgradováním na Flutter 2.10.0 a upgradem auto_route knihovny se rozbily zase routy na přihlašovací obrazovku
([issue](https://github.com/Milad-Akarie/auto_route_library/issues/496): nedá se pushovat z dekalritvní na routu která má childy, tak je to takové ohackované alespoň že se pushne routa která nemá childy a pak s childama)