### PR TITLE
fix: timepicker bugfixes

### DIFF
--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -197,7 +197,7 @@
   "@colonoscopy_question_highlight": {},
   "oculist_question_highlight": "Očního lékaře",
   "@oculist_question_highlight": {},
-  "dermatology_question_highlight": "Dermatologii",
+  "dermatology_question_highlight": "Dermatologa",
   "@dermatology_question_highlight": {},
   "mammogram_question_highlight": "Mamografu",
   "@mammogram_question_highlight": {},

--- a/lib/ui/screens/prevention/examination_detail/new_time_screen.dart
+++ b/lib/ui/screens/prevention/examination_detail/new_time_screen.dart
@@ -10,7 +10,7 @@ import 'package:loono/models/categorized_examination.dart';
 import 'package:loono/repositories/calendar_repository.dart';
 import 'package:loono/repositories/examination_repository.dart';
 import 'package:loono/router/app_router.gr.dart';
-import 'package:loono/ui/widgets/button.dart';
+import 'package:loono/ui/widgets/async_button.dart';
 import 'package:loono/ui/widgets/custom_time_picker.dart';
 import 'package:loono/utils/registry.dart';
 
@@ -102,23 +102,9 @@ class _NewTimeScreenState extends State<NewTimeScreen> {
                 ),
               ),
               const Spacer(),
-              /*AsyncLoonoButton(
+              AsyncLoonoApiButton(
                 text: context.l10n.action_save,
-                asyncCallback: () => registry.get<ExaminationRepository>().postExamination(
-                      examinationType,
-                      newDate: newDate!,
-                    ),
-                onSuccess: () async {
-                  AutoRouter.of(context).popUntilRouteWithName('ExaminationDetailRoute');
-                  showSnackBarSuccess(context, message: context.l10n.checkup_reminder_toast);
-                },
-                onError: () {
-                  showSnackBarError(context, message: context.l10n.something_went_wrong);
-                },
-              ),*/
-              LoonoButton(
-                text: context.l10n.action_save,
-                onTap: () async {
+                asyncCallback: () async {
                   final response = await registry.get<ExaminationRepository>().postExamination(
                         examinationType,
                         newDate: newDate!,

--- a/lib/ui/widgets/custom_time_picker.dart
+++ b/lib/ui/widgets/custom_time_picker.dart
@@ -11,8 +11,8 @@ class CustomTimePicker extends StatefulWidget {
     Key? key,
     required this.valueChanged,
     required this.defaultDate,
-    this.defaultHour = 9,
-    this.defaultMinute = 0,
+    this.defaultHour,
+    this.defaultMinute,
     this.filled = false,
   }) : super(key: key);
 
@@ -29,8 +29,9 @@ class CustomTimePicker extends StatefulWidget {
 class _CustomTimePickerState extends State<CustomTimePicker> {
   late int _selectedHourIndex = 0;
   late int _selectedMinuteIndex = 0;
-  late final int _defaultHour = widget.defaultHour!;
-  late final int _defaultMinute = widget.defaultMinute!;
+  late final int _defaultHour = widget.defaultHour ?? 9;
+  late final int _defaultMinute = widget.defaultMinute ?? 0;
+
   late DateTime timePickerDate = widget.defaultDate;
 
   @override

--- a/lib/ui/widgets/custom_time_picker.dart
+++ b/lib/ui/widgets/custom_time_picker.dart
@@ -12,12 +12,14 @@ class CustomTimePicker extends StatefulWidget {
     required this.valueChanged,
     required this.defaultDate,
     this.defaultHour = 9,
+    this.defaultMinute = 0,
     this.filled = false,
   }) : super(key: key);
 
   final ValueChanged<DateTime> valueChanged;
   final DateTime defaultDate;
-  final int defaultHour;
+  final int? defaultHour;
+  final int? defaultMinute;
   final bool filled;
 
   @override
@@ -27,7 +29,8 @@ class CustomTimePicker extends StatefulWidget {
 class _CustomTimePickerState extends State<CustomTimePicker> {
   late int _selectedHourIndex = 0;
   late int _selectedMinuteIndex = 0;
-  late final int _defaultHour = widget.defaultHour;
+  late final int _defaultHour = widget.defaultHour!;
+  late final int _defaultMinute = widget.defaultMinute!;
   late DateTime timePickerDate = widget.defaultDate;
 
   @override
@@ -86,7 +89,12 @@ class _CustomTimePickerState extends State<CustomTimePicker> {
   List<int> get _timePickerMinutes {
     final minutes = [for (var i = 0; i <= 55; i += 5) i];
 
-    return minutes;
+    final roundedDefaultMinute = (_defaultMinute.clamp(0, 55) / 5).round() * 5;
+
+    final minutesShifted = minutes.sublist(minutes.indexOf(roundedDefaultMinute), minutes.length) +
+        minutes.sublist(0, minutes.indexOf(roundedDefaultMinute));
+
+    return minutesShifted;
   }
 
   Widget _datePickerColumn({required ColumnType forType}) {

--- a/lib/ui/widgets/prevention/datepicker_sheet.dart
+++ b/lib/ui/widgets/prevention/datepicker_sheet.dart
@@ -5,7 +5,7 @@ import 'package:loono/constants.dart';
 import 'package:loono/helpers/examination_detail_helpers.dart';
 import 'package:loono/l10n/ext.dart';
 import 'package:loono/models/categorized_examination.dart';
-import 'package:loono/ui/widgets/button.dart';
+import 'package:loono/ui/widgets/async_button.dart';
 import 'package:loono/ui/widgets/custom_date_picker.dart';
 import 'package:loono/ui/widgets/custom_time_picker.dart';
 
@@ -100,7 +100,7 @@ class _DatePickerContentState extends State<_DatePickerContent> {
         procedureQuestionTitle(context, examinationType: examinationType).toLowerCase();
     final preposition = czechPreposition(context, examinationType: examinationType);
 
-    final originalDate = widget.categorizedExamination.examination.plannedDate;
+    final originalDate = widget.categorizedExamination.examination.plannedDate?.toLocal();
 
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -155,15 +155,26 @@ class _DatePickerContentState extends State<_DatePickerContent> {
               : CustomTimePicker(
                   valueChanged: onTimeChanged,
                   defaultDate: newDate!,
-                  defaultHour: 12,
+                  defaultHour: originalDate?.hour,
+                  defaultMinute: originalDate?.minute,
                 ),
         ),
         const Spacer(),
-        LoonoButton(
+        AsyncLoonoApiButton(
           text: isFirstStep ? context.l10n.continue_info : context.l10n.action_save,
           enabled: newDate != null,
-          onTap: () async {
+          asyncCallback: () async {
             if (isFirstStep) {
+              if (originalDate != null) {
+                /// preset original date
+                newDate = DateTime(
+                  newDate!.year,
+                  newDate!.month,
+                  newDate!.day,
+                  originalDate.hour.clamp(0, 23),
+                  originalDate.minute.clamp(0, 55),
+                );
+              }
               setState(() {
                 isFirstStep = false;
               });

--- a/lib/ui/widgets/prevention/examination_edit_modal.dart
+++ b/lib/ui/widgets/prevention/examination_edit_modal.dart
@@ -43,8 +43,8 @@ void showEditModal(BuildContext pageContext, CategorizedExamination examination)
     );
   }
 
-  final formattedDate =
-      DateFormat('d. MMMM yyyy, kk:mm', 'cs-CZ').format(examination.examination.plannedDate!);
+  final formattedDate = DateFormat('d. MMMM yyyy, kk:mm', 'cs-CZ')
+      .format(examination.examination.plannedDate!.toLocal());
 
   showCupertinoModalPopup<void>(
     context: pageContext,


### PR DESCRIPTION
Opravuje stav, kdy u změny prohlídky uživatel nevybere čas. Padalo to na 00:00. 
Navíc teď předvyplňuje známý čas z minulé prohlídky.
Vyměněno jedno button bez loadingu a pár minor úprav.