### PR TITLE
fix: wait for user onboard

### DIFF
--- a/lib/models/firebase_user.dart
+++ b/lib/models/firebase_user.dart
@@ -17,4 +17,6 @@ class AuthUser {
 
   Future<String> getIdToken({bool forceRefresh = false}) async =>
       _firebaseUser.getIdToken(forceRefresh);
+
+  Future<void> delete() async => _firebaseUser.delete();
 }

--- a/lib/ui/screens/main/pre_auth/onboarding_form_done.dart
+++ b/lib/ui/screens/main/pre_auth/onboarding_form_done.dart
@@ -115,8 +115,15 @@ class OnboardingFormDoneScreen extends StatelessWidget {
                         showSnackBarError(context, message: context.l10n.something_went_wrong);
                         return;
                       }
-                      await _onboardUser(authUser, user, examinationQuestionnaires);
-                      await AutoRouter.of(context).push(NicknameRoute(authUser: authUser));
+                      final result = await _onboardUser(authUser, user, examinationQuestionnaires);
+                      result.when(
+                        success: (_) =>
+                            AutoRouter.of(context).push(NicknameRoute(authUser: authUser)),
+                        // TODO: we have to handle case if the server is down - user account will be created on Firebase but no information will be saved to BE.
+                        // User can then login in but will not see any data.
+                        failure: (_) =>
+                            showSnackBarError(context, message: context.l10n.something_went_wrong),
+                      );
                     },
                   );
                 },
@@ -138,8 +145,13 @@ class OnboardingFormDoneScreen extends StatelessWidget {
                         showSnackBarError(context, message: context.l10n.something_went_wrong);
                         return;
                       }
-                      await _onboardUser(authUser, user, examinationQuestionnaires);
-                      await AutoRouter.of(context).push(NicknameRoute(authUser: authUser));
+                      final result = await _onboardUser(authUser, user, examinationQuestionnaires);
+                      result.when(
+                        success: (_) =>
+                            AutoRouter.of(context).push(NicknameRoute(authUser: authUser)),
+                        failure: (_) =>
+                            showSnackBarError(context, message: context.l10n.something_went_wrong),
+                      );
                     },
                   );
                 },

--- a/lib/ui/screens/main/pre_auth/onboarding_form_done.dart
+++ b/lib/ui/screens/main/pre_auth/onboarding_form_done.dart
@@ -1,5 +1,6 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:built_collection/built_collection.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:loono/constants.dart';
@@ -111,18 +112,15 @@ class OnboardingFormDoneScreen extends StatelessWidget {
                       final user = _usersDao.user;
                       final examinationQuestionnaires =
                           await _examinationQuestionnairesDao.getAll();
-                      if (user == null || examinationQuestionnaires.isEmpty) {
-                        showSnackBarError(context, message: context.l10n.something_went_wrong);
-                        return;
-                      }
                       final result = await _onboardUser(authUser, user, examinationQuestionnaires);
-                      result.when(
+                      await result.when(
                         success: (_) =>
                             AutoRouter.of(context).push(NicknameRoute(authUser: authUser)),
-                        // TODO: we have to handle case if the server is down - user account will be created on Firebase but no information will be saved to BE.
-                        // User can then login in but will not see any data.
-                        failure: (_) =>
-                            showSnackBarError(context, message: context.l10n.something_went_wrong),
+                        failure: (_) async {
+                          showSnackBarError(context, message: context.l10n.something_went_wrong);
+                          // delete account so user can not login without saving info to server first
+                          await authUser.delete();
+                        },
                       );
                     },
                   );
@@ -141,16 +139,14 @@ class OnboardingFormDoneScreen extends StatelessWidget {
                       final user = _usersDao.user;
                       final examinationQuestionnaires =
                           await _examinationQuestionnairesDao.getAll();
-                      if (user == null || examinationQuestionnaires.isEmpty) {
-                        showSnackBarError(context, message: context.l10n.something_went_wrong);
-                        return;
-                      }
                       final result = await _onboardUser(authUser, user, examinationQuestionnaires);
-                      result.when(
+                      await result.when(
                         success: (_) =>
                             AutoRouter.of(context).push(NicknameRoute(authUser: authUser)),
-                        failure: (_) =>
-                            showSnackBarError(context, message: context.l10n.something_went_wrong),
+                        failure: (_) async {
+                          showSnackBarError(context, message: context.l10n.something_went_wrong);
+                          await authUser.delete();
+                        },
                       );
                     },
                   );
@@ -183,9 +179,12 @@ class OnboardingFormDoneScreen extends StatelessWidget {
 
   Future<ApiResponse<Account>> _onboardUser(
     AuthUser authUser,
-    User user,
+    User? user,
     List<ExaminationQuestionnaire> examinationQuestionnaires,
-  ) {
+  ) async {
+    if (user == null || examinationQuestionnaires.isEmpty) {
+      return ApiResponse.failure(DioError(requestOptions: RequestOptions(path: '')));
+    }
     final generalPractitioner = examinationQuestionnaires.generalPractitionerQuestionnaire;
     final gynecologist = examinationQuestionnaires.gynecologistQuestionnaire;
     final dentist = examinationQuestionnaires.dentistQuestionnaire;


### PR DESCRIPTION
@MartinMacek párkrát se mi stalo, že to API call failnul a stejně dalo na next screen. ~~Musíme pak nějak pořešit ten case pokud je server dole, na Firebase se mu stejěn účet založí. Pak se může v login screeně přihlásit, ale nikdy neuvidí svý data, protože se reálně neuložily na BE.~~ pokud request failne, smaže se účet z Firebase