### PR TITLE
feat: Prevention api calls update + retry interceptor

### DIFF
--- a/lib/repositories/examination_repository.dart
+++ b/lib/repositories/examination_repository.dart
@@ -22,10 +22,9 @@ class ExaminationRepository {
   }
 
   Future<ApiResponse<ExaminationRecord>> cancelExamination(
-    ExaminationType type,
     String uuid,
   ) async {
-    final response = await _apiService.cancelExamination(type, uuid);
+    final response = await _apiService.cancelExamination(uuid);
     return response;
   }
 
@@ -47,10 +46,9 @@ class ExaminationRepository {
   }
 
   Future<ApiResponse<ExaminationRecord>> confirmExamination(
-    ExaminationType type, {
     String? uuid,
-  }) async {
-    final response = await _apiService.confirmExamination(type, id: uuid);
+  ) async {
+    final response = await _apiService.confirmExamination(uuid);
     return response;
   }
 }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -111,7 +111,6 @@ class ApiService {
   }
 
   Future<ApiResponse<ExaminationRecord>> cancelExamination(
-    ExaminationType type,
     String uuid,
   ) async {
     return _callApi(
@@ -157,9 +156,8 @@ class ApiService {
   }
 
   Future<ApiResponse<ExaminationRecord>> confirmExamination(
-    ExaminationType type, {
     String? id,
-  }) async {
+  ) async {
     return _callApi(
       () async => _api.getExaminationsApi().completeExamination(
         examinationId: ExaminationId((newId) {

--- a/lib/ui/screens/prevention/examination_detail/examination_detail.dart
+++ b/lib/ui/screens/prevention/examination_detail/examination_detail.dart
@@ -15,6 +15,7 @@ import 'package:loono/router/app_router.gr.dart';
 import 'package:loono/services/calendar_service.dart';
 import 'package:loono/services/database_service.dart';
 import 'package:loono/services/db/database.dart';
+import 'package:loono/services/examinations_service.dart';
 import 'package:loono/ui/screens/prevention/examination_detail/faq_section.dart';
 import 'package:loono/ui/widgets/button.dart';
 import 'package:loono/ui/widgets/prevention/calendar_permission_sheet.dart';
@@ -27,6 +28,7 @@ import 'package:loono/ui/widgets/prevention/examination_progress_content.dart';
 import 'package:loono/ui/widgets/prevention/last_visit_sheet.dart';
 import 'package:loono/utils/registry.dart';
 import 'package:loono_api/loono_api.dart';
+import 'package:provider/provider.dart';
 
 class ExaminationDetail extends StatelessWidget {
   ExaminationDetail({
@@ -87,12 +89,22 @@ class ExaminationDetail extends StatelessWidget {
 
     /// not ideal in build method but need context
     Future<void> _onPostNewCheckupSubmit({required DateTime date}) async {
+      /// code anchor: #postNewExamination
       final response = await registry.get<ExaminationRepository>().postExamination(
             _examinationType,
             newDate: date,
+            uuid: categorizedExamination.examination.uuid,
+            firstExam: false,
+            status: ExaminationStatus.NEW,
           );
+
       response.map(
         success: (res) {
+          Provider.of<ExaminationsProvider>(context, listen: false)
+              .updateExaminationsRecord(res.data);
+          AutoRouter.of(context).popUntilRouteWithName(
+            ExaminationDetailRoute(categorizedExamination: categorizedExamination).routeName,
+          );
           showSnackBarSuccess(context, message: context.l10n.checkup_reminder_toast);
         },
         failure: (err) {

--- a/lib/ui/screens/prevention/questionnaire/schedule_examination.dart
+++ b/lib/ui/screens/prevention/questionnaire/schedule_examination.dart
@@ -75,33 +75,52 @@ class ScheduleExamination extends StatelessWidget {
                                 DatePickerRoute(
                                   assetPath: _examinationType.assetPath,
                                   title: _examinationType.l10n_name,
-                                  onSkipButtonPress: (date) {
-                                    // TODO: save to api, navigate to updated ExaminationDetail
-                                    showSnackBarError(context, message: 'TODO: save to API');
-                                    _appRouter.navigate(const MainScreenRouter());
-                                  },
-                                  onContinueButtonPress: (pickedDate) async {
-                                    // TODO: save to api, navigate to updated ExaminationDetail
-
+                                  onSkipButtonPress: (date) async {
+                                    /// code anchor: #postFirstNewExaminationUnknownDate
                                     final response =
                                         await registry.get<ExaminationRepository>().postExamination(
                                               _examinationType,
+                                              uuid: examinationRecord.uuid,
+                                              firstExam: true,
+                                              status: ExaminationStatus.UNKNOWN,
+                                              newDate: date,
+                                            );
+                                    response.map(
+                                      success: (res) {
+                                        Provider.of<ExaminationsProvider>(context, listen: false)
+                                            .updateExaminationsRecord(res.data);
+                                        _appRouter.navigate(const MainScreenRouter());
+                                      },
+                                      failure: (err) {
+                                        _appRouter.navigate(const MainScreenRouter());
+                                        showSnackBarError(
+                                          context,
+                                          message: context.l10n.something_went_wrong,
+                                        );
+                                      },
+                                    );
+                                  },
+                                  onContinueButtonPress: (pickedDate) async {
+                                    /// code anchor: #postFirstNewExaminationKnownDate
+                                    final response =
+                                        await registry.get<ExaminationRepository>().postExamination(
+                                              _examinationType,
+                                              uuid: examinationRecord.uuid,
+                                              firstExam: true,
+                                              status: ExaminationStatus.CONFIRMED,
                                               newDate: pickedDate,
                                             );
                                     response.map(
                                       success: (res) {
                                         Provider.of<ExaminationsProvider>(context, listen: false)
-                                            .fetchExaminations();
+                                            .updateExaminationsRecord(res.data);
                                         _appRouter.navigate(const MainScreenRouter());
-
                                         showSnackBarSuccess(
                                           context,
                                           message: context.l10n.checkup_reminder_toast,
                                         );
                                       },
                                       failure: (err) {
-                                        Provider.of<ExaminationsProvider>(context, listen: false)
-                                            .fetchExaminations();
                                         _appRouter.navigate(const MainScreenRouter());
                                         showSnackBarError(
                                           context,
@@ -120,10 +139,25 @@ class ScheduleExamination extends StatelessWidget {
                   ),
                 );
               },
-              nextCallback2: () {
-                // TODO: save to api, navigate to updated ExaminationDetail
-                showSnackBarError(context, message: 'TODO: save to API');
-                _appRouter.navigate(const MainScreenRouter());
+              nextCallback2: () async {
+                /// code anchor: #postFirstNewExaminationMore
+                final response = await registry.get<ExaminationRepository>().postExamination(
+                      _examinationType,
+                      uuid: examinationRecord.uuid,
+                      firstExam: true,
+                      status: ExaminationStatus.UNKNOWN,
+                    );
+                await response.map(
+                  success: (res) async {
+                    Provider.of<ExaminationsProvider>(context, listen: false)
+                        .updateExaminationsRecord(res.data);
+                    await _appRouter.navigate(const MainScreenRouter());
+                  },
+                  failure: (error) async {
+                    await _appRouter.pop();
+                    showSnackBarError(context, message: context.l10n.something_went_wrong);
+                  },
+                );
               },
             ),
           ),

--- a/lib/ui/widgets/badges/badge_composer.dart
+++ b/lib/ui/widgets/badges/badge_composer.dart
@@ -103,35 +103,42 @@ class _BadgeComposerState extends State<BadgeComposer> {
             StreamBuilder<User?>(
               stream: _usersDao.watchUser(),
               builder: (context, snapshot) {
-                final sex = snapshot.data?.sex ?? Sex.FEMALE;
+                final sex = snapshot.data?.sex;
                 final badges = snapshot.data?.badges ?? BuiltList(<Badge>[]);
 
                 int _levelOf(BadgeType type) {
-                  return badges.firstWhereOrNull((e) => e.type == type)?.level ?? 0;
+                  final level = badges.firstWhereOrNull((e) => e.type == type)?.level;
+                  if (level != null && level > 5) {
+                    debugPrint(
+                      '⚠️ debug hint: app currently supports only 5 levels of badge assets ⚠️',
+                    );
+                  }
+                  return level?.clamp(0, 5) ?? 0;
                 }
 
                 return SizedBox(
                   width: 180,
                   height: 300,
-                  child: Stack(
-                    key: ValueKey(sex),
-                    children: [
-                      _getCloak(_levelOf(BadgeType.COAT)),
-                      SvgPicture.asset(
-                        sex == Sex.MALE
-                            ? 'assets/badges/body/man.svg'
-                            : 'assets/badges/body/woman.svg',
-                      ),
-                      _getHeadband(_levelOf(BadgeType.HEADBAND)),
-                      _getGoogles(sex, _levelOf(BadgeType.GLASSES)),
-                      _getBoots(_levelOf(BadgeType.SHOES)),
-                      if (sex == Sex.FEMALE) _getArmour(_levelOf(BadgeType.TOP)),
-                      _getBelt(sex, _levelOf(BadgeType.BELT)),
-                      _getCloakBuckle(_levelOf(BadgeType.COAT)),
-                      _getGloves(sex, _levelOf(BadgeType.GLOVES)),
-                      _getShield(_levelOf(BadgeType.SHIELD)),
-                    ],
-                  ),
+                  child: sex != null
+                      ? Stack(
+                          children: [
+                            _getCloak(_levelOf(BadgeType.COAT)),
+                            SvgPicture.asset(
+                              sex == Sex.MALE
+                                  ? 'assets/badges/body/man.svg'
+                                  : 'assets/badges/body/woman.svg',
+                            ),
+                            _getHeadband(_levelOf(BadgeType.HEADBAND)),
+                            _getGoogles(sex, _levelOf(BadgeType.GLASSES)),
+                            _getBoots(_levelOf(BadgeType.SHOES)),
+                            if (sex == Sex.FEMALE) _getArmour(_levelOf(BadgeType.TOP)),
+                            _getBelt(sex, _levelOf(BadgeType.BELT)),
+                            _getCloakBuckle(_levelOf(BadgeType.COAT)),
+                            _getGloves(sex, _levelOf(BadgeType.GLOVES)),
+                            _getShield(_levelOf(BadgeType.SHIELD)),
+                          ],
+                        )
+                      : const SizedBox(),
                 );
               },
             ),

--- a/lib/ui/widgets/badges/badge_composer.dart
+++ b/lib/ui/widgets/badges/badge_composer.dart
@@ -17,6 +17,8 @@ class BadgeComposer extends StatefulWidget {
 class _BadgeComposerState extends State<BadgeComposer> {
   final _usersDao = registry.get<DatabaseService>().users;
 
+  static const supportedBadgeLevels = 5;
+
   Widget _getGoogles(Sex sex, int level) {
     return level > 0
         ? SvgPicture.asset(
@@ -108,12 +110,12 @@ class _BadgeComposerState extends State<BadgeComposer> {
 
                 int _levelOf(BadgeType type) {
                   final level = badges.firstWhereOrNull((e) => e.type == type)?.level;
-                  if (level != null && level > 5) {
+                  if (level != null && level > supportedBadgeLevels) {
                     debugPrint(
-                      '⚠️ debug hint: app currently supports only 5 levels of badge assets ⚠️',
+                      '⚠️ debug hint: app currently supports only $supportedBadgeLevels levels of badge assets ⚠️',
                     );
                   }
-                  return level?.clamp(0, 5) ?? 0;
+                  return level?.clamp(0, supportedBadgeLevels) ?? 0;
                 }
 
                 return SizedBox(

--- a/lib/ui/widgets/prevention/examination_cancel_sheet.dart
+++ b/lib/ui/widgets/prevention/examination_cancel_sheet.dart
@@ -82,14 +82,12 @@ void showCancelExaminationSheet({
               const SizedBox(
                 height: 60,
               ),
-
-              /// old api implementation, needs api update
               AsyncLoonoApiButton(
                 text: context.l10n.cancel_checkup,
                 asyncCallback: () async {
-                  final response = await registry
-                      .get<ExaminationRepository>()
-                      .cancelExamination(examinationType, id);
+                  /// code anchor: #postCancelExamiantion
+                  final response =
+                      await registry.get<ExaminationRepository>().cancelExamination(id);
                   await response.map(
                     success: (res) async {
                       await registry.get<CalendarRepository>().deleteEvent(examinationType);

--- a/lib/ui/widgets/prevention/examination_confirm_sheet.dart
+++ b/lib/ui/widgets/prevention/examination_confirm_sheet.dart
@@ -50,16 +50,12 @@ void showConfirmationSheet(
             const SizedBox(
               height: 60,
             ),
-
-            /// old api implementation, needs api update
             AsyncLoonoApiButton(
               text:
                   '${l10n.yes}, ${sex == Sex.MALE ? l10n.checkup_confirmation_male.toLowerCase() : l10n.checkup_confirmation_female.toLowerCase()}',
               asyncCallback: () async {
-                final response = await _api.confirmExamination(
-                  examinationType,
-                  uuid: uuid,
-                );
+                /// code anchor: #postConfirmExamiantion
+                final response = await _api.confirmExamination(uuid);
                 await response.map(
                   success: (res) async {
                     await _calendar.deleteOnlyDbEvent(examinationType);

--- a/lib/ui/widgets/prevention/examination_edit_modal.dart
+++ b/lib/ui/widgets/prevention/examination_edit_modal.dart
@@ -21,10 +21,12 @@ void showEditModal(BuildContext pageContext, CategorizedExamination examination)
       procedureQuestionTitle(pageContext, examinationType: examinationType).toLowerCase();
 
   Future<void> onChangeSubmit({required DateTime date}) async {
+    /// code anchor: #postChangeExamiantion
     final response = await registry.get<ExaminationRepository>().postExamination(
           examinationType,
           newDate: date,
           uuid: examination.examination.uuid,
+          firstExam: false,
         );
     await response.map(
       success: (res) async {

--- a/lib/ui/widgets/prevention/examinations_sheet_overlay.dart
+++ b/lib/ui/widgets/prevention/examinations_sheet_overlay.dart
@@ -35,8 +35,17 @@ class _ExaminationsSheetOverlayState extends State<ExaminationsSheetOverlay> {
               minChildSize: 0.15,
               builder: (context, scrollController) {
                 if (examinationsProvider.examinations == null) {
-                  return const Center(
-                    child: Text('žádné záznamy'),
+                  return Center(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        const Text('žádné záznamy'),
+                        TextButton(
+                          onPressed: examinationsProvider.fetchExaminations,
+                          child: const Text('zkusit znovu'),
+                        ),
+                      ],
+                    ),
                   );
                 }
                 final categorized = examinationsProvider.examinations!.examinations

--- a/lib/ui/widgets/settings/avatar.dart
+++ b/lib/ui/widgets/settings/avatar.dart
@@ -37,8 +37,12 @@ class LoonoAvatar extends StatelessWidget {
                     backgroundColor: Colors.white,
                     foregroundImage: imageProvider,
                   ),
-                  placeholder: (context, url) => const Center(
-                    child: CircularProgressIndicator(color: LoonoColors.primaryEnabled),
+                  placeholder: (context, url) => Center(
+                    child: SizedBox(
+                      height: radius,
+                      width: radius,
+                      child: const CircularProgressIndicator(color: LoonoColors.primaryEnabled),
+                    ),
                   ),
                   errorWidget: (context, url, dynamic error) =>
                       DefaultLoonoCircleAvatar(radius: radius),

--- a/lib/utils/registry.dart
+++ b/lib/utils/registry.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:device_calendar/device_calendar.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:dio/dio.dart';
+import 'package:dio_smart_retry/dio_smart_retry.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
@@ -66,7 +67,22 @@ Future<void> setup(AppFlavors flavor) async {
     flavor: flavor,
   );
 
-  registry.registerSingleton<LoonoApi>(LoonoApi(dio: Dio(defaultDioOptions)));
+  final dio = Dio(defaultDioOptions);
+  dio.interceptors.add(
+    RetryInterceptor(
+      dio: dio,
+      logPrint: print,
+      retries: 3,
+      retryDelays: const [
+        // set delays between retries
+        Duration(seconds: 1),
+        Duration(seconds: 2),
+        Duration(seconds: 3),
+      ],
+    ),
+  );
+
+  registry.registerSingleton<LoonoApi>(LoonoApi(dio: dio));
 
   registry.registerLazySingleton<GlobalKey<NavigatorState>>(() => GlobalKey());
   registry.registerLazySingleton<AppConfig>(() => config);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -316,6 +316,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.4"
+  dio_smart_retry:
+    dependency: "direct main"
+    description:
+      name: dio_smart_retry
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   drift:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   device_info_plus: ^3.2.1
   diacritic: ^0.1.3
   dio: ^4.0.0
+  dio_smart_retry: ^1.1.0
   email_validator: ^2.0.1
   encrypted_moor:
     git:


### PR DESCRIPTION
Aktualizovány všechny cally prevence na api podle dokumentu od Lukáše. Přepsal jsem aktuální stav do [(tohoto) sdíleného docu, který odpovídá tomuhle PR](https://docs.google.com/document/d/1M27Bhlucd_lyVo93eVWTcovqWsirKWlF0DPMPjhuqO0/edit?usp=sharing).
Přidán Dio interceptor na retry callů.
Fixnul problikávání hrdiny po načtení a zastropoval jsem badge levels na 5, aby se předešlo chybám.

note: code anchors slouží pro rychlejší navigaci mezi dokumetací a přesným místem v kódu.