### PR TITLE
fix(prevention): main screen card statuses

### DIFF
--- a/lib/helpers/examination_extensions.dart
+++ b/lib/helpers/examination_extensions.dart
@@ -14,10 +14,9 @@ extension ExaminationPreventionStatusExt on ExaminationPreventionStatus {
     final now = dateTimeNow ?? DateTime.now();
 
     // STATUS: waiting or newToSchedule
-    if (plannedDate == null && lastConfirmedDate != null) {
-      final lastVisitDateWithoutDay = lastConfirmedDate!;
-      final lastVisitDateTime =
-          DateTime(lastVisitDateWithoutDay.year, lastVisitDateWithoutDay.month);
+    if (state == ExaminationStatus.CONFIRMED && lastConfirmedDate != null) {
+      final lastVisitDateTime = lastConfirmedDate!.toLocal();
+      final lastVisitDateWithoutDay = DateTime(lastVisitDateTime.year, lastVisitDateTime.month);
 
       // if last visit date is before: CURRENT_MONTH - (INTERVAL - 2 months)
       final subtractedWaitingDate = DateTime(
@@ -25,17 +24,21 @@ extension ExaminationPreventionStatusExt on ExaminationPreventionStatus {
         now.month - (intervalYears * MONTHS_IN_YEAR - TO_SCHEDULE_MONTHS_TRANSFER),
       );
       // then waiting time has ended, move to "TO BE SCHEDULED"
-      if (lastVisitDateTime.isBefore(subtractedWaitingDate) ||
-          lastVisitDateTime.isAtSameMomentAs(subtractedWaitingDate)) {
+      if (lastVisitDateWithoutDay.isBefore(subtractedWaitingDate) ||
+          lastVisitDateWithoutDay.isAtSameMomentAs(subtractedWaitingDate)) {
         return const ExaminationCategory.newToSchedule();
       }
       // else wait
       return const ExaminationCategory.waiting();
     }
 
+    if (state == ExaminationStatus.UNKNOWN) {
+      return const ExaminationCategory.newToSchedule();
+    }
+
     // STATUS: scheduled or scheduledSoonOrOverdue
     if (plannedDate != null) {
-      final diffInDaysFromNow = plannedDate!.difference(now).inDays;
+      final diffInDaysFromNow = plannedDate!.toLocal().difference(now).inDays;
       // if it is more than 30 days before the check-up visit the status is "SCHEDULED"
       if (diffInDaysFromNow > 30) return const ExaminationCategory.scheduled();
       // else 30 days or equal before check-up visit the status is "SCHEDULED_SOON_OR_OVERDUE"

--- a/lib/ui/widgets/prevention/examination_card.dart
+++ b/lib/ui/widgets/prevention/examination_card.dart
@@ -140,7 +140,7 @@ class ExaminationCard extends StatelessWidget {
   }
 
   List<Widget> _waitingContent() {
-    final lastDateVisit = categorizedExamination.examination.lastConfirmedDate!;
+    final lastDateVisit = categorizedExamination.examination.lastConfirmedDate!.toLocal();
     final newWaitToDateTime = DateTime(
       lastDateVisit.year + categorizedExamination.examination.intervalYears,
       lastDateVisit.month,
@@ -185,7 +185,7 @@ class ExaminationCard extends StatelessWidget {
   }
 
   Widget dateRow() {
-    final formattedDate = DateFormat('d. M. yyyy kk:mm', 'cs-CZ')
+    final formattedDate = DateFormat('d. M. yyyy hh:mm', 'cs-CZ')
         .format(categorizedExamination.examination.plannedDate!.toLocal());
 
     return Row(

--- a/lib/ui/widgets/prevention/examination_edit_modal.dart
+++ b/lib/ui/widgets/prevention/examination_edit_modal.dart
@@ -45,7 +45,7 @@ void showEditModal(BuildContext pageContext, CategorizedExamination examination)
     );
   }
 
-  final formattedDate = DateFormat('d. MMMM yyyy, kk:mm', 'cs-CZ')
+  final formattedDate = DateFormat('d. MMMM yyyy, hh:mm', 'cs-CZ')
       .format(examination.examination.plannedDate!.toLocal());
 
   showCupertinoModalPopup<void>(

--- a/lib/ui/widgets/prevention/examination_progress_content.dart
+++ b/lib/ui/widgets/prevention/examination_progress_content.dart
@@ -35,10 +35,7 @@ class ExaminationProgressContent extends StatelessWidget {
     ].contains(categorizedExamination.category)) {
       /// known next visit
       return _scheduledVisitContent(context);
-    } else if ([
-      const ExaminationCategory.newToSchedule(),
-      const ExaminationCategory.waiting(),
-    ].contains(categorizedExamination.category)) {
+    } else if ([const ExaminationCategory.waiting()].contains(categorizedExamination.category)) {
       /// awaiting new checkup
       return _earlyCheckupContent(context);
     } else if (categorizedExamination.examination.lastConfirmedDate != null) {
@@ -52,6 +49,10 @@ class ExaminationProgressContent extends StatelessWidget {
         ),
       );
     } else {
+      if (categorizedExamination.examination.state == ExaminationStatus.CONFIRMED) {
+        return _earlyCheckupContent(context);
+      }
+
       /// first examination
       return Text(
         context.l10n.first_visit_awaiting,


### PR DESCRIPTION
upravena počítání logika statusů
u těch statusů tam zůstala ještě logika z tý doby, kdy statusy nebyly, takže to vůbec nesedělo s tím co tam má být...

https://cesko-digital.atlassian.net/browse/LOON-525
https://cesko-digital.atlassian.net/browse/LOON-524