### PR TITLE
LOON-367 precaching images

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:loono/loono.dart';
 import 'package:loono/utils/app_config.dart';
-import 'package:loono/utils/picture_precaching.dart';
 import 'package:loono/utils/registry.dart';
 
 Future<void> main() async {
   await setup(flavor: AppFlavors.dev);
-  final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
-  FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
-  await precacheImagesFromList(welcomeSplashes);
   runApp(const Loono());
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,10 +3,22 @@ import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:loono/loono.dart';
 import 'package:loono/utils/app_config.dart';
 import 'package:loono/utils/registry.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 
 Future<void> main() async {
+  const imgRoutes = ['assets/icons/carousel_doctors.svg'];
   await setup(flavor: AppFlavors.dev);
   final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
+  await Future.forEach<String>(
+      imgRoutes,
+      (imgRoute) => precachePicture(
+            ExactAssetPicture(
+              SvgPicture.svgStringDecoderBuilder,
+              imgRoute,
+            ),
+            null,
+            onError: (e, st) => print(e),
+          ));
   runApp(const Loono());
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,23 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:loono/loono.dart';
 import 'package:loono/utils/app_config.dart';
+import 'package:loono/utils/picture_precaching.dart';
 import 'package:loono/utils/registry.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 
 Future<void> main() async {
-  const imgRoutes = ['assets/icons/carousel_doctors.svg'];
   await setup(flavor: AppFlavors.dev);
   final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
-  await Future.forEach<String>(
-      imgRoutes,
-      (imgRoute) => precachePicture(
-            ExactAssetPicture(
-              SvgPicture.svgStringDecoderBuilder,
-              imgRoute,
-            ),
-            null,
-            onError: (e, st) => print(e),
-          ));
+  await precacheImagesFromList(welcomeSplashes);
   runApp(const Loono());
 }

--- a/lib/utils/picture_precaching.dart
+++ b/lib/utils/picture_precaching.dart
@@ -1,0 +1,17 @@
+import 'dart:async';
+import 'package:flutter_svg/flutter_svg.dart';
+
+const welcomeSplashes = ['assets/icons/carousel_doctors.svg', 'assets/icons/people.svg'];
+
+Future<void> precacheImagesFromList(List<String> imgRoutes) async {
+  await Future.forEach<String>(
+    imgRoutes,
+    (imgRoute) => precachePicture(
+      ExactAssetPicture(
+        SvgPicture.svgStringDecoderBuilder,
+        imgRoute,
+      ),
+      null,
+    ),
+  );
+}

--- a/lib/utils/registry.dart
+++ b/lib/utils/registry.dart
@@ -13,6 +13,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:get_it/get_it.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:image_picker/image_picker.dart';
@@ -30,6 +31,7 @@ import 'package:loono/services/firebase_storage_service.dart';
 import 'package:loono/services/notification_service.dart';
 import 'package:loono/services/save_directories.dart';
 import 'package:loono/utils/app_config.dart';
+import 'package:loono/utils/picture_precaching.dart';
 import 'package:loono_api/loono_api.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 
@@ -189,4 +191,11 @@ Future<void> setup({
   // utils
   registry.registerLazySingleton<ImagePicker>(() => ImagePicker());
   registry.registerLazySingleton<DefaultCacheManager>(() => DefaultCacheManager());
+
+  // picture caching
+  await precacheImagesFromList(welcomeSplashes);
+
+  // splash screen
+  final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
+  FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
 }


### PR DESCRIPTION
Scalable reseni, jak precachovat obrazky (nejen) na startupu appky. Vsechnu logiku a resources jsem extrahoval do zvlastniho souboru, kde jsou zatim jen 2 obrazky v listu, ale dobudoucna se muzou pridat dalsi listy s dalsimi obrazky a precachovat kdekoliv jinde ve flow appky.