### PR TITLE
feat(android): Add debugSymbolLevel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
 
 env:
   flutter_version: '2.10.1'
+  android_ndk: '21.4.7075529'
 
 jobs:
   android:
@@ -68,6 +69,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
+          ndk: ${{ env.android_ndk }}
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
@@ -80,6 +82,7 @@ jobs:
           target: ${{ matrix.target }}
           api-level: ${{ matrix.api-level }}
           arch: x86_64
+          ndk: ${{ env.android_ndk }}
           force-avd-creation: false
           disable-animations: true
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -37,6 +37,7 @@ project.ext.envConfigFiles = [
 
 android {
     compileSdkVersion 31
+    ndkVersion "21.4.7075529"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -51,6 +52,9 @@ android {
 
 //        "added due to: The number of method references in a .dex file cannot exceed 64k"
         multiDexEnabled true
+        ndk {
+            debugSymbolLevel 'SYMBOL_TABLE'
+        }
     }
 
     signingConfigs {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.0'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.8'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.5.1'

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -64,6 +64,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.2.1"
+  badges:
+    dependency: "direct main"
+    description:
+      name: badges
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   boolean_selector:
     dependency: transitive
     description:


### PR DESCRIPTION
Zkouším přidat debugSymbolLevel který by měl nahrát debug symbols do google play a zbavit se tak jednoho warningu.
Musel jsem aktualizovat kotlin a gradle. První build trvá docela dlouho, než se všechno stáhne ale další už běží normálně.
Narazil jsem na nějaké čerstvé [issues](https://github.com/flutter/flutter/issues/99381) s nefunkčními flavors, tak uvidíme jestli na to narazíme taky. Musí to projít codemagicem aby došlo k podepsání bundlu.