### PR TITLE
fix(auth): sign up with apple

### DIFF
--- a/lib/models/social_login_account.dart
+++ b/lib/models/social_login_account.dart
@@ -5,26 +5,27 @@ import 'package:loono/helpers/social_login_helpers.dart';
 import 'package:loono/models/firebase_user.dart';
 import 'package:loono/services/auth/auth_service.dart';
 import 'package:loono/services/auth/failures.dart';
+import 'package:loono/utils/crypto_utils.dart';
 import 'package:loono/utils/registry.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
 class SocialLoginAccount {
-  const SocialLoginAccount.apple(AuthorizationCredentialAppleID appleID, String nonce)
+  const SocialLoginAccount.apple(AuthorizationCredentialAppleID appleID, CryptoNonce cryptoNonce)
       : _socialLoginMethod = SocialLoginMethod.apple,
         _googleUser = null,
-        _nonce = nonce,
+        _cryptoNonce = cryptoNonce,
         _appleID = appleID;
 
   const SocialLoginAccount.google(GoogleSignInAccount googleUser)
       : _socialLoginMethod = SocialLoginMethod.google,
         _appleID = null,
-        _nonce = null,
+        _cryptoNonce = null,
         _googleUser = googleUser;
 
   final SocialLoginMethod _socialLoginMethod;
   final GoogleSignInAccount? _googleUser;
   final AuthorizationCredentialAppleID? _appleID;
-  final String? _nonce;
+  final CryptoNonce? _cryptoNonce;
 
   String? get email {
     switch (_socialLoginMethod) {
@@ -48,7 +49,7 @@ class SocialLoginAccount {
     final authService = registry.get<AuthService>();
     switch (_socialLoginMethod) {
       case SocialLoginMethod.apple:
-        return authService.signInWithApple(_appleID?.identityToken, _nonce);
+        return authService.signInWithApple(_appleID?.identityToken, _cryptoNonce);
       case SocialLoginMethod.google:
         return authService.signInWithGoogle(_googleUser);
     }

--- a/lib/models/social_login_account.dart
+++ b/lib/models/social_login_account.dart
@@ -9,21 +9,22 @@ import 'package:loono/utils/registry.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 
 class SocialLoginAccount {
-  const SocialLoginAccount.apple(
-    this._appleID,
-  )   : assert(_appleID != null),
-        _socialLoginMethod = SocialLoginMethod.apple,
-        _googleUser = null;
+  const SocialLoginAccount.apple(AuthorizationCredentialAppleID appleID, String nonce)
+      : _socialLoginMethod = SocialLoginMethod.apple,
+        _googleUser = null,
+        _nonce = nonce,
+        _appleID = appleID;
 
-  const SocialLoginAccount.google(
-    this._googleUser,
-  )   : assert(_googleUser != null),
-        _socialLoginMethod = SocialLoginMethod.google,
-        _appleID = null;
+  const SocialLoginAccount.google(GoogleSignInAccount googleUser)
+      : _socialLoginMethod = SocialLoginMethod.google,
+        _appleID = null,
+        _nonce = null,
+        _googleUser = googleUser;
 
   final SocialLoginMethod _socialLoginMethod;
   final GoogleSignInAccount? _googleUser;
   final AuthorizationCredentialAppleID? _appleID;
+  final String? _nonce;
 
   String? get email {
     switch (_socialLoginMethod) {
@@ -47,7 +48,7 @@ class SocialLoginAccount {
     final authService = registry.get<AuthService>();
     switch (_socialLoginMethod) {
       case SocialLoginMethod.apple:
-        return authService.signInWithApple(_appleID?.userIdentifier);
+        return authService.signInWithApple(_appleID?.identityToken, _nonce);
       case SocialLoginMethod.google:
         return authService.signInWithGoogle(_googleUser);
     }

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -72,21 +72,25 @@ class AuthService {
   }
 
   Future<Either<AuthFailure, AuthUser>> checkAppleAccountExistsAndSignIn() async {
-    final nonce = getNonce();
-    final appleCredential = await getAppleCredential(nonce);
+    final cryptoNonce = CryptoNonce();
+    final appleCredential = await getAppleCredential(cryptoNonce);
 
     if (appleCredential == null) return const Left(AuthFailure.unknown());
     if (appleCredential.email == null) {
-      return Left(AuthFailure.accountNotExists(SocialLoginAccount.apple(appleCredential, nonce)));
+      return Left(
+        AuthFailure.accountNotExists(SocialLoginAccount.apple(appleCredential, cryptoNonce)),
+      );
     }
 
     final signInMethods = await _auth.fetchSignInMethodsForEmail(appleCredential.email!);
     if (signInMethods.isEmpty) {
-      return Left(AuthFailure.accountNotExists(SocialLoginAccount.apple(appleCredential, nonce)));
+      return Left(
+        AuthFailure.accountNotExists(SocialLoginAccount.apple(appleCredential, cryptoNonce)),
+      );
     }
 
     // account exists, sign in
-    final authResult = await signInWithApple(appleCredential.identityToken, nonce);
+    final authResult = await signInWithApple(appleCredential.identityToken, cryptoNonce);
     return authResult;
   }
 
@@ -131,7 +135,7 @@ class AuthService {
 
   Future<Either<AuthFailure, AuthUser>> signInWithApple([
     String? existingIdToken,
-    String? existingNonce,
+    CryptoNonce? existingNonce,
   ]) async {
     assert(
       (existingIdToken != null && existingNonce != null) ||
@@ -143,7 +147,8 @@ class AuthService {
     // match the sha256 hash of `rawNonce`.
 
     AuthorizationCredentialAppleID? appleCredential;
-    final nonce = existingNonce ?? getNonce();
+
+    final cryptoNonce = existingNonce ?? CryptoNonce();
 
     if (existingIdToken == null) {
       try {
@@ -152,7 +157,7 @@ class AuthService {
             AppleIDAuthorizationScopes.email,
             AppleIDAuthorizationScopes.fullName,
           ],
-          nonce: nonce,
+          nonce: cryptoNonce.nonce,
         );
       } on SignInWithAppleException catch (_) {
         // TODO: find out network error code
@@ -164,7 +169,7 @@ class AuthService {
 
     final oauthCredential = OAuthProvider('apple.com').credential(
       idToken: existingIdToken ?? appleCredential?.identityToken,
-      rawNonce: nonce,
+      rawNonce: cryptoNonce.rawNonce,
     );
 
     UserCredential? userCredential;
@@ -178,8 +183,8 @@ class AuthService {
         : Right(_authUserFromFirebase(userCredential.user)!);
   }
 
-  Future<AuthorizationCredentialAppleID?> getAppleCredential([String? existingNonce]) async {
-    final nonce = existingNonce ?? getNonce();
+  Future<AuthorizationCredentialAppleID?> getAppleCredential([CryptoNonce? existingNonce]) async {
+    final cryptoNonce = existingNonce ?? CryptoNonce();
 
     AuthorizationCredentialAppleID? appleCredential;
     try {
@@ -188,7 +193,7 @@ class AuthService {
           AppleIDAuthorizationScopes.email,
           AppleIDAuthorizationScopes.fullName,
         ],
-        nonce: nonce,
+        nonce: cryptoNonce.nonce,
       );
     } catch (o) {
       debugPrint(o.toString());

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -77,12 +77,12 @@ class AuthService {
 
     if (appleCredential == null) return const Left(AuthFailure.unknown());
     if (appleCredential.email == null) {
-      return Left(AuthFailure.accountNotExists(SocialLoginAccount.apple(appleCredential)));
+      return Left(AuthFailure.accountNotExists(SocialLoginAccount.apple(appleCredential, nonce)));
     }
 
     final signInMethods = await _auth.fetchSignInMethodsForEmail(appleCredential.email!);
     if (signInMethods.isEmpty) {
-      return Left(AuthFailure.accountNotExists(SocialLoginAccount.apple(appleCredential)));
+      return Left(AuthFailure.accountNotExists(SocialLoginAccount.apple(appleCredential, nonce)));
     }
 
     // account exists, sign in
@@ -133,6 +133,10 @@ class AuthService {
     String? existingIdToken,
     String? existingNonce,
   ]) async {
+    assert(
+      (existingIdToken != null && existingNonce != null) ||
+          (existingIdToken == null && existingNonce == null),
+    );
     // To prevent replay attacks with the credential returned from Apple, we
     // include a nonce in the credential request. When signing in with
     // Firebase, the nonce in the id token returned by Apple, is expected to

--- a/lib/utils/crypto_utils.dart
+++ b/lib/utils/crypto_utils.dart
@@ -10,4 +10,14 @@ String sha256ofString(String input) {
   return digest.toString();
 }
 
-String getNonce() => sha256ofString(generateNonce());
+String generateSecureNonce() => generateNonce();
+
+class CryptoNonce {
+  CryptoNonce() {
+    rawNonce = generateSecureNonce();
+    nonce = sha256ofString(rawNonce);
+  }
+
+  late final String nonce;
+  late final String rawNonce;
+}


### PR DESCRIPTION
- fixnuta jen registrace, testnuta že funguje by @PetrVachulka
- opětovné přihlášení se bude muset ještě pořešit (to nefungovalo AFAIK ani předtím).

> A ohledně zpětného loginu, v [dokumentaci](https://pub.dev/documentation/sign_in_with_apple_platform_interface/latest/authorization_credential/AuthorizationCredentialAppleID/email.html) jsem četl že email jde získat jen 1x a pak ho už nevíme. A abychom zjistili, jestli existuje účet, tak na to používáme metodu [fetchSignInMethodsForEmail](https://pub.dev/documentation/firebase_auth/latest/firebase_auth/FirebaseAuth/fetchSignInMethodsForEmail.html) z Firebase.. jenže když ten email nevíme tak nezjsitíme jestli účet s tím mailem existuje.. říkal jsem to kdysi s [@Jana Hejnova](https://cesko-digital.slack.com/team/U017YUFFX2S), ale už nevím jak to dopadlo :smile: