### PR TITLE
Show apple social buttons only on ios

### DIFF
--- a/lib/ui/screens/main/pre_auth/login.dart
+++ b/lib/ui/screens/main/pre_auth/login.dart
@@ -1,3 +1,4 @@
+import 'dart:io' show Platform;
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' as s;
@@ -82,21 +83,23 @@ class LoginScreen extends StatelessWidget {
               width: MediaQuery.of(context).size.width,
             ),
             const Spacer(flex: 2),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 18.0),
-              child: SocialLoginButton.apple(
-                onPressed: () async {
-                  final accountExistsResult = await _authService.checkAppleAccountExistsAndSignIn();
-                  accountExistsResult.fold(
-                    (failure) => showSnackBarError(context, message: failure.getMessage(context)),
-                    (authUser) async {
-                      await _userRepository.createUserIfNotExists();
-                      await AutoRouter.of(context).replaceAll([const MainScreenRouter()]);
-                    },
-                  );
-                },
+            if (Platform.isIOS)
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 18.0),
+                child: SocialLoginButton.apple(
+                  onPressed: () async {
+                    final accountExistsResult =
+                        await _authService.checkAppleAccountExistsAndSignIn();
+                    accountExistsResult.fold(
+                      (failure) => showSnackBarError(context, message: failure.getMessage(context)),
+                      (authUser) async {
+                        await _userRepository.createUserIfNotExists();
+                        await AutoRouter.of(context).replaceAll([const MainScreenRouter()]);
+                      },
+                    );
+                  },
+                ),
               ),
-            ),
             const SizedBox(height: 20.0),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 18.0),

--- a/lib/ui/screens/main/pre_auth/onboarding_form_done.dart
+++ b/lib/ui/screens/main/pre_auth/onboarding_form_done.dart
@@ -1,3 +1,4 @@
+import 'dart:io' show Platform;
 import 'package:auto_route/auto_route.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
@@ -95,15 +96,16 @@ class OnboardingFormDoneScreen extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 30),
-            Padding(
-              padding: const EdgeInsets.only(top: 18, left: 18, right: 18),
-              child: SocialLoginButton.apple(
-                onPressed: () async => _processSocialAuth(
-                  context,
-                  socialLoginMethod: SocialLoginMethod.apple,
+            if (Platform.isIOS)
+              Padding(
+                padding: const EdgeInsets.only(top: 18, left: 18, right: 18),
+                child: SocialLoginButton.apple(
+                  onPressed: () async => _processSocialAuth(
+                    context,
+                    socialLoginMethod: SocialLoginMethod.apple,
+                  ),
                 ),
               ),
-            ),
             const SizedBox(height: 15),
             Padding(
               padding: const EdgeInsets.only(left: 18, right: 18),


### PR DESCRIPTION
Self explanatory. Prihlasit se pres Apple na androidu nam atm nefunguje, takze je dobry napad tuto moznost uplne schovat. Dobudoucna se nejak tento login da resit i na androidu, ale to bude chtit vetsi poinvestigovani, je to dost corner case a neni to potreba v MVP.