### PR TITLE
fix(onboarding): date time interval api error

### DIFF
--- a/lib/models/examination_questionnaire.dart
+++ b/lib/models/examination_questionnaire.dart
@@ -103,7 +103,7 @@ class ExaminationQuestionnairesDao extends DatabaseAccessor<AppDatabase>
     await updateQuestionnaire(
       examinationType,
       examinationQuestionnairesCompanion: ExaminationQuestionnairesCompanion(
-        date: Value<DateTime>(DateTime.now()),
+        date: Value<DateTime>(Date.now().toDateTime()),
         status: const Value<ExaminationStatus>(ExaminationStatus.UNKNOWN),
       ),
     );


### PR DESCRIPTION
Pokud se zadá v onboardingu "Nevím", vyskočí pak v registraci error. Způsobila předtím změna že se posílal DateTime v UTC