### PR TITLE
feat(firebase): more setups, delete user files on delete account

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Notes
 ## Integration Tests
 - **Make sure to <ins>clear the app's</ins> data before running the tests.** (Android)
 - To run all frontend (UI) tests on an emulator or on a real iOS / Android device, first connect the device and run the following command from the root of the project:
-`flutter test integration_test --test-randomize-ordering-seed=random --flavor dev integration_test/test_sets/app_test.dart`.
+`flutter test --test-randomize-ordering-seed=random --flavor dev integration_test/test_sets/app_test.dart`.
 - Or, you can run a specific TC or a group with:
 `flutter test integration_test/test_sets/app_test.dart --plain-name "TC(LOON_437): Logout (straight path)" --flavor dev`
-- To run BE tests which test real API, add generated `CUSTOM_TOKEN` to ./assets/.env. You can run the test then with: `flutter test integration_test --flavor dev integration_test/test_sets/be_test.dart`.
+- To run BE tests which test real API, add generated `CUSTOM_TOKEN` to ./assets/.env. You can run the test then with: `flutter test --flavor dev integration_test/test_sets/be_test.dart`.
 - Since the app is in active development, tests are expected to fail often. No need to fix them right away.
 - Conventions:
     - test case implementation is inspired by POM (Page Object Model) design pattern

--- a/lib/services/firebase_storage_service.dart
+++ b/lib/services/firebase_storage_service.dart
@@ -17,11 +17,13 @@ class FirebaseStorageService {
   /// If `null` then there is not any on-going task.
   UploadTask? uploadTask;
 
+  Reference _getUserFolderRef(String uid) => _storage.ref().child('users').child(uid);
+
   /// Returns [Reference] location of the user's avatar.
   Future<Reference?> get userPhotoRef async {
     final uid = await _authService.userUid;
     if (uid == null) return null;
-    return _storage.ref().child('users').child(uid).child('files').child('avatar.png');
+    return _getUserFolderRef(uid).child('files').child('avatar.png');
   }
 
   // TODO: Error handling (https://cesko-digital.atlassian.net/browse/LOON-386)
@@ -57,5 +59,13 @@ class FirebaseStorageService {
     if (ref == null) return null;
     await ref.delete();
     return true;
+  }
+
+  /// Delete all user's files.
+  Future<void> deleteAll() async {
+    final refs = [
+      await userPhotoRef,
+    ].whereType<Reference>();
+    await Future.wait<void>([for (final ref in refs) ref.delete()]);
   }
 }

--- a/lib/utils/app_clear.dart
+++ b/lib/utils/app_clear.dart
@@ -1,17 +1,20 @@
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:loono/services/auth/auth_service.dart';
 import 'package:loono/services/database_service.dart';
+import 'package:loono/services/firebase_storage_service.dart';
 import 'package:loono/services/notification_service.dart';
 import 'package:loono/services/secure_storage_service.dart';
 import 'package:loono/utils/registry.dart';
 
 Future<void> appClear({bool deletingAccount = false}) async {
+  if (deletingAccount) {
+    await registry.get<FirebaseStorageService>().deleteAll();
+  }
   await registry.get<AuthService>().signOut();
   await registry.get<DatabaseService>().clearDb();
   await registry.get<SecureStorageService>().deleteAll();
+  await registry.get<NotificationService>().removeUserId();
 
   // clears saved user avatar and other app's temp data
   await registry.get<DefaultCacheManager>().emptyCache();
-
-  await registry.get<NotificationService>().removeUserId();
 }

--- a/lib/utils/registry.dart
+++ b/lib/utils/registry.dart
@@ -10,6 +10,8 @@ import 'package:dio_smart_retry/dio_smart_retry.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -61,6 +63,7 @@ Future<void> setup({
 }) async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
+  await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(!kDebugMode);
 
   final appInfo = await PackageInfo.fromPlatform();
   await dotenv.load(fileName: 'assets/.env');

--- a/lib/utils/registry.dart
+++ b/lib/utils/registry.dart
@@ -160,6 +160,7 @@ Future<void> setup({
   );
 
   registry.registerSingleton<FirebaseAnalytics>(FirebaseAnalytics.instance);
+  await registry.get<FirebaseAnalytics>().setAnalyticsCollectionEnabled(!kDebugMode);
 
   registry.registerSingleton<LoonoApi>(LoonoApi(dio: dio));
 


### PR DESCRIPTION
- enabled Crashlytics in non-debug mode (test crash se projevil se v konzoli)
- disabled Analytics in debug mode
- delete user files from FB Storage on delete account

a ještě setupnuto FB Storage, ale v kodu asi zadne změny nejsou třeba
mensi update starych instrukci v Readme