### PR TITLE
feat(notification): Navigate to examinations

### DIFF
--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -2,9 +2,16 @@ import 'dart:async';
 import 'dart:developer';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:loono/helpers/examination_extensions.dart';
+import 'package:loono/models/categorized_examination.dart';
+import 'package:loono/router/app_router.gr.dart';
+import 'package:loono/services/api_service.dart';
+
 import 'package:loono/utils/app_config.dart';
 import 'package:loono/utils/registry.dart';
+import 'package:loono_api/loono_api.dart';
 import 'package:onesignal_flutter/onesignal_flutter.dart';
 
 class NotificationService {
@@ -13,7 +20,7 @@ class NotificationService {
   final _permissionController = StreamController<OSNotificationPermission>.broadcast();
 
   Future<void> init() async {
-    await OneSignal.shared.setLogLevel(OSLogLevel.verbose, OSLogLevel.none);
+    await OneSignal.shared.setLogLevel(OSLogLevel.info, OSLogLevel.none);
     final appId = getEnvString(
       dotenv.env,
       registry.get<AppConfig>().flavor == AppFlavors.dev
@@ -22,9 +29,50 @@ class NotificationService {
     );
     await OneSignal.shared.setAppId(appId);
     OneSignal.shared.setPermissionObserver(_onPermissionStateChanges);
-    OneSignal.shared.setNotificationOpenedHandler((OSNotificationOpenedResult res) {
-      /// TODO: handle notification action
-      log(res.notification.toString());
+    OneSignal.shared.setNotificationOpenedHandler((OSNotificationOpenedResult res) async {
+      final notificationExaminationType = res.notification.additionalData?.entries
+          .singleWhereOrNull((element) => element.key == 'examinationType')
+          ?.value
+          .toString();
+      await registry.get<ApiService>().getExaminations().then((res) {
+        res.map(
+          success: (exams) {
+            final examinationToOpen = exams.data.examinations.firstWhereOrNull(
+              (element) => element.examinationType.toString() == notificationExaminationType,
+            );
+            if (examinationToOpen != null) {
+              registry.get<AppRouter>().push(
+                    ExaminationDetailRoute(
+                      categorizedExamination: CategorizedExamination(
+                        examination: examinationToOpen,
+                        category: examinationToOpen.calculateStatus(),
+                      ),
+                    ),
+                  );
+              return;
+            }
+
+            final selfExaminationToOpen = exams.data.selfexaminations.firstWhereOrNull(
+              (element) => element.type.toString() == notificationExaminationType,
+            );
+            if (selfExaminationToOpen != null) {
+              registry.get<AppRouter>().push(
+                    SelfExaminationDetailRoute(
+                      sex: selfExaminationToOpen.type == SelfExaminationType.TESTICULAR
+                          ? Sex.MALE
+                          : Sex.FEMALE,
+                      selfExamination: selfExaminationToOpen,
+                    ),
+                  );
+              return;
+            }
+            log('Failed to recognize examination from notification');
+          },
+          failure: (err) {
+            log('Unable to fetch examination data for notifications');
+          },
+        );
+      });
     });
   }
 

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -34,6 +34,9 @@ class NotificationService {
           .singleWhereOrNull((element) => element.key == 'examinationType')
           ?.value
           .toString();
+
+      if (notificationExaminationType == null) return;
+
       await registry.get<ApiService>().getExaminations().then((res) {
         res.map(
           success: (exams) {


### PR DESCRIPTION
Přidán notification open handler který pushne danou examination po tapnutí na notifku na základě jejího typu. 
Z notifikací čte additional data s klíčem `examinationType` a jako value rozeznává **examinationType** nebo **selfExamination.type**.

Povolené values jsou tedy: `COLONOSCOPY`,`DENTIST`,`DERMATOLOGIST`,`GENERAL_PRACTITIONER`,`GYNECOLOGIST`,`MAMMOGRAM`,`OPHTHALMOLOGIST`,`TOKS`,`ULTRASOUND_BREAST`,`UROLOGIST`,`VENEREAL_DISEASES` 
nebo 
`BREAST`,`TESTICULAR`