### PR TITLE
feat(tools): setup mason

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ app.*.map.json
 
 # Custom
 .env
+/.mason/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ Notes
   developers or might differ from the ones generated via the CodeMagic pipeline. We also commit them to
   avoid spending time and money when building the app on CodeMagic.
 
+### Mason templates
+- [Mason](https://pub.dev/packages/mason_cli) is Dart template generator which helps teams generate files quickly and consistently.
+- To install mason, run: `dart pub global activate mason_cli`
+- Currently used templates (bricks):
+    - pom_class - A template for generating Page Object Model (POM) class.
+- Then from the root of the project you can quickly make generate a file from a template:
+```
+mason get
+mason list
+mason make pom_class
+```
+
 ## App internalizations
 
 - Currently app supports only Czech language, all texts used within the app should be located in `lib/l10n/intl_cs.arb`. Supporting new languages can be made by adding new language arb file.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,6 +5,7 @@ analyzer:
     - "**/*.g.dart"
     - "**/*.freezed.dart"
     - "**/*.gr.dart"
+    - "bricks/**/*.dart"
 
   # See https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks
   strong-mode:

--- a/bricks/pom_class/__brick__/{{screenName.snakeCase()}}_page.dart
+++ b/bricks/pom_class/__brick__/{{screenName.snakeCase()}}_page.dart
@@ -9,13 +9,14 @@ class {{screenName}}Page {
   final WidgetTester tester;
 
   /// Page finders
-  final Finder somethingOnPage = find.byKey(const Key('page_widget_name'));
+  final Finder _somethingOnPage = find.byKey(const Key('page_widget_name'));
 
   /// Page methods
   {{#hasButton}}
-  Future<void> clickSomeButton() async {
+  // ignore: unused_element
+  Future<void> _clickSomeButton() async {
     {{#addLogs}}logTestEvent();{{/addLogs}}
-    await tester.tap(somethingOnPage);
+    await tester.tap(_somethingOnPage);
     await tester.pumpAndSettle();
   }
   {{/hasButton}}

--- a/bricks/pom_class/__brick__/{{screenName.snakeCase()}}_page.dart
+++ b/bricks/pom_class/__brick__/{{screenName.snakeCase()}}_page.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// TODO: Implement Page Objects
+/// * Corresponding screen: [{{screenName}}Screen]
+class {{screenName}}Page {
+{{screenName}}Page(this.tester);
+
+  final WidgetTester tester;
+
+  /// Page finders
+  final Finder somethingOnPage = find.byKey(const Key('page_widget_name'));
+
+  /// Page methods
+  {{#hasButton}}
+  Future<void> clickSomeButton() async {
+    {{#addLogs}}logTestEvent();{{/addLogs}}
+    await tester.tap(somethingOnPage);
+    await tester.pumpAndSettle();
+  }
+  {{/hasButton}}
+
+  Future<void> verifyScreenIsShown() async {
+    {{#addLogs}}logTestEvent();{{/addLogs}}
+    await tester.pumpUntilFound(find.byType({{screenName}}Screen));
+  }
+}

--- a/bricks/pom_class/brick.yaml
+++ b/bricks/pom_class/brick.yaml
@@ -1,0 +1,32 @@
+name: pom_class
+description: Template for Page Object Model (POM) class.
+
+# The following defines the version and build number for your brick.
+# A version number is three numbers separated by dots, like 1.2.34
+# followed by an optional build number (separated by a +).
+version: 0.0.1
+
+# The following defines the environment for the current brick.
+# It includes the version of mason that the brick requires.
+environment:
+  mason: ">=0.1.0-dev <0.1.0"
+
+# Variables specify dynamic values that your brick depends on.
+# Zero or more variables can be specified for a given brick.
+# Each variable has:
+#  * a type (string, number, or boolean)
+#  * an optional short description
+#  * an optional default value
+#  * an optional prompt phrase used when asking for the variable.
+vars:
+  screenName:
+    type: string
+    prompt: Screen class name
+  hasButton:
+    type: boolean
+    default: true
+    prompt: Does the screen have a button?
+  addLogs:
+    type: boolean
+    default: true
+    prompt: Add logging method to action methods?

--- a/bricks/pom_class/brick.yaml
+++ b/bricks/pom_class/brick.yaml
@@ -21,7 +21,7 @@ environment:
 vars:
   screenName:
     type: string
-    prompt: Screen class name
+    prompt: Screen class name (e.g. for "LoginScreen" type "Login")
   hasButton:
     type: boolean
     default: true

--- a/integration_test/test_helpers/widget_tester_extensions.dart
+++ b/integration_test/test_helpers/widget_tester_extensions.dart
@@ -9,14 +9,14 @@ extension WidgetTesterExt on WidgetTester {
     await pump(Duration(seconds: seconds));
   }
 
-  Future<void> pumpUntilNotVisible(
+  Future<void> pumpUntilNotFound(
     Finder finder, {
     Duration timeout = const Duration(seconds: 20),
   }) async {
     await _pumpUntil(finder, timeout: timeout, untilVisible: false);
   }
 
-  Future<void> pumpUntilVisible(
+  Future<void> pumpUntilFound(
     Finder finder, {
     Duration timeout = const Duration(seconds: 20),
   }) async {

--- a/integration_test/test_sets/app/flows/login_flow.dart
+++ b/integration_test/test_sets/app/flows/login_flow.dart
@@ -45,7 +45,7 @@ Future<void> loginFlow({
     );
 
   await tester.pumpAndSettle();
-  await tester.pumpUntilVisible(find.byType(WelcomeScreen));
+  await tester.pumpUntilFound(find.byType(WelcomeScreen));
 
   await welcomePage.clickLoginButton();
   expect(find.byType(LoginScreen), findsOneWidget);

--- a/integration_test/test_sets/app/pages/force_update_page.dart
+++ b/integration_test/test_sets/app/pages/force_update_page.dart
@@ -21,6 +21,6 @@ class ForceUpdatePage {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(ForceUpdateScreen));
+    await tester.pumpUntilFound(find.byType(ForceUpdateScreen));
   }
 }

--- a/integration_test/test_sets/app/pages/login_page.dart
+++ b/integration_test/test_sets/app/pages/login_page.dart
@@ -32,6 +32,6 @@ class LoginPage {
     logTestEvent();
     await tester.tap(createNewAccountBtn);
     await tester.pumpAndSettle();
-    await tester.pumpUntilNotVisible(createNewAccountBtn);
+    await tester.pumpUntilNotFound(createNewAccountBtn);
   }
 }

--- a/integration_test/test_sets/app/pages/logout_page.dart
+++ b/integration_test/test_sets/app/pages/logout_page.dart
@@ -17,6 +17,6 @@ class LogoutPage {
     logTestEvent();
     await tester.tap(loginBtn);
     await tester.pumpAndSettle();
-    await tester.pumpUntilNotVisible(find.byType(LogoutScreen));
+    await tester.pumpUntilNotFound(find.byType(LogoutScreen));
   }
 }

--- a/integration_test/test_sets/app/pages/post_auth_main_screen_page.dart
+++ b/integration_test/test_sets/app/pages/post_auth_main_screen_page.dart
@@ -41,7 +41,7 @@ class PostAuthMainScreenPage with MainScreenFinders {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(MainScreen));
+    await tester.pumpUntilFound(find.byType(MainScreen));
   }
 
   void verifyBottomBarIsShown() {

--- a/integration_test/test_sets/app/pages/pre_auth_main_screen_page.dart
+++ b/integration_test/test_sets/app/pages/pre_auth_main_screen_page.dart
@@ -38,6 +38,6 @@ class PreAuthMainScreenPage with MainScreenFinders {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(PreAuthMainScreen));
+    await tester.pumpUntilFound(find.byType(PreAuthMainScreen));
   }
 }

--- a/integration_test/test_sets/app/pages/welcome_page.dart
+++ b/integration_test/test_sets/app/pages/welcome_page.dart
@@ -19,13 +19,13 @@ class WelcomePage {
     logTestEvent();
     await tester.tap(startBtn);
     await tester.pump(const Duration(seconds: 2));
-    await tester.pumpUntilNotVisible(find.byType(WelcomeScreen));
+    await tester.pumpUntilNotFound(find.byType(WelcomeScreen));
   }
 
   Future<void> clickLoginButton() async {
     logTestEvent();
     await tester.tap(loginBtn);
     await tester.pumpAndSettle();
-    await tester.pumpUntilNotVisible(find.byType(WelcomeScreen));
+    await tester.pumpUntilNotFound(find.byType(WelcomeScreen));
   }
 }

--- a/integration_test/test_sets/app/test_cases/be_flow.dart
+++ b/integration_test/test_sets/app/test_cases/be_flow.dart
@@ -74,22 +74,22 @@ Future<void> run({required WidgetTester tester}) async {
   final pointsHelpPage = PointsHelpPage(tester);
 
   // start questionnaire and create a new account
-  await tester.pumpUntilVisible(find.byType(WelcomeScreen));
+  await tester.pumpUntilFound(find.byType(WelcomeScreen));
 
   await welcomePage.clickLoginButton();
-  await tester.pumpUntilVisible(find.byType(LoginScreen));
+  await tester.pumpUntilFound(find.byType(LoginScreen));
 
   await loginPage.clickCreateNewAccountButton();
-  await tester.pumpUntilVisible(find.byType(OnboardingGenderScreen));
+  await tester.pumpUntilFound(find.byType(OnboardingGenderScreen));
 
   await questionnaireGenderPage.chooseMaleGender();
   await questionnaireGenderPage.clickContinueButton();
 
-  await tester.pumpUntilVisible(find.byType(OnBoardingBirthdateScreen));
+  await tester.pumpUntilFound(find.byType(OnBoardingBirthdateScreen));
   expect(find.text('Kdy ses narodil?'), findsOneWidget);
 
   await questionnaireBirthDatePage.clickContinueButton();
-  await tester.pumpUntilVisible(find.byType(OnboardingGeneralPracticionerScreen));
+  await tester.pumpUntilFound(find.byType(OnboardingGeneralPracticionerScreen));
 
   await questionnaireDoctorCcaLastVisitPage.clickMoreThanXYearsOrIdkButton(
     nextScreen: OnboardingDentistScreen,
@@ -100,7 +100,7 @@ Future<void> run({required WidgetTester tester}) async {
   );
 
   await questionnaireAchievementPage.clickContinueButton();
-  await tester.pumpUntilVisible(find.byType(DentistDateScreen));
+  await tester.pumpUntilFound(find.byType(DentistDateScreen));
 
   await questionnaireDoctorDatePickerPage.clickIdkButton();
   await onboardingFormDonePage.verifyScreenIsShown();
@@ -128,7 +128,7 @@ Future<void> run({required WidgetTester tester}) async {
   await preventionMainPage.verifyScreenIsShown();
 
   // verify some data are fetched from api GET /examinations
-  await tester.pumpUntilVisible(find.byType(SelfExaminationCard));
+  await tester.pumpUntilFound(find.byType(SelfExaminationCard));
   preventionMainPage
     ..verifyHasBadge(BadgeType.HEADBAND)
     ..verifyDoesNotHaveBadge(BadgeType.SHIELD)

--- a/integration_test/test_sets/find_doctor/pages/find_doctor_page.dart
+++ b/integration_test/test_sets/find_doctor/pages/find_doctor_page.dart
@@ -14,6 +14,6 @@ class FindDoctorPage {
   /// Page methods
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(FindDoctorScreen));
+    await tester.pumpUntilFound(find.byType(FindDoctorScreen));
   }
 }

--- a/integration_test/test_sets/onboarding/pages/gamification_introduction_page.dart
+++ b/integration_test/test_sets/onboarding/pages/gamification_introduction_page.dart
@@ -23,6 +23,6 @@ class GamificationIntroductionPage {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(GamificationIntroductionScreen));
+    await tester.pumpUntilFound(find.byType(GamificationIntroductionScreen));
   }
 }

--- a/integration_test/test_sets/onboarding/pages/intro_video_page.dart
+++ b/integration_test/test_sets/onboarding/pages/intro_video_page.dart
@@ -17,7 +17,7 @@ class IntroVideoPage {
 
   /// Page methods
   Future<void> waitForVideoLoad() async {
-    await tester.pumpUntilNotVisible(find.byType(CircularProgressIndicator));
+    await tester.pumpUntilNotFound(find.byType(CircularProgressIndicator));
   }
 
   Future<void> clickContinueBtn() async {

--- a/integration_test/test_sets/onboarding/pages/onboarding_form_done_page.dart
+++ b/integration_test/test_sets/onboarding/pages/onboarding_form_done_page.dart
@@ -22,6 +22,6 @@ class OnboardingFormDonePage {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(OnboardingFormDoneScreen));
+    await tester.pumpUntilFound(find.byType(OnboardingFormDoneScreen));
   }
 }

--- a/integration_test/test_sets/onboarding/pages/questionnaire/doctor_cca_last_visit_page.dart
+++ b/integration_test/test_sets/onboarding/pages/questionnaire/doctor_cca_last_visit_page.dart
@@ -18,13 +18,13 @@ class QuestionnaireDoctorCcaLastVisitPage with OnboardingFinders {
     logTestEvent();
     await tester.tap(inLastXYearsBtn);
     await tester.pumpAndSettle();
-    await tester.pumpUntilVisible(find.byType(nextScreen));
+    await tester.pumpUntilFound(find.byType(nextScreen));
   }
 
   Future<void> clickMoreThanXYearsOrIdkButton({required Type nextScreen}) async {
     logTestEvent();
     await tester.tap(moreThanXYearsOrIdkButton);
     await tester.pumpAndSettle();
-    await tester.pumpUntilVisible(find.byType(nextScreen));
+    await tester.pumpUntilFound(find.byType(nextScreen));
   }
 }

--- a/integration_test/test_sets/onboarding/pages/sign_up_email_page.dart
+++ b/integration_test/test_sets/onboarding/pages/sign_up_email_page.dart
@@ -28,6 +28,6 @@ class SignUpEmailPage {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(EmailScreen));
+    await tester.pumpUntilFound(find.byType(EmailScreen));
   }
 }

--- a/integration_test/test_sets/onboarding/pages/sign_up_nickname_page.dart
+++ b/integration_test/test_sets/onboarding/pages/sign_up_nickname_page.dart
@@ -28,6 +28,6 @@ class SignUpNicknamePage {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(NicknameScreen));
+    await tester.pumpUntilFound(find.byType(NicknameScreen));
   }
 }

--- a/integration_test/test_sets/prevention/pages/examination/examination_detail_page.dart
+++ b/integration_test/test_sets/prevention/pages/examination/examination_detail_page.dart
@@ -11,13 +11,14 @@ class ExaminationDetailPage {
   final WidgetTester tester;
 
   /// Page finders
-  final Finder somethingOnPage = find.byKey(const Key('page_widget_name'));
+  final Finder _somethingOnPage = find.byKey(const Key('page_widget_name'));
 
   /// Page methods
 
-  Future<void> clickSomeButton() async {
+  // ignore: unused_element
+  Future<void> _clickSomeButton() async {
     logTestEvent();
-    await tester.tap(somethingOnPage);
+    await tester.tap(_somethingOnPage);
     await tester.pumpAndSettle();
   }
 

--- a/integration_test/test_sets/prevention/pages/examination/examination_detail_page.dart
+++ b/integration_test/test_sets/prevention/pages/examination/examination_detail_page.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:loono/ui/screens/prevention/examination_detail/examination_screen.dart';
+
+import '../../../../test_helpers/widget_tester_extensions.dart';
+
+/// * Corresponding screen: [ExaminationDetailScreen]
+class ExaminationDetailPage {
+  ExaminationDetailPage(this.tester);
+
+  final WidgetTester tester;
+
+  /// Page finders
+  final Finder somethingOnPage = find.byKey(const Key('page_widget_name'));
+
+  /// Page methods
+
+  Future<void> clickSomeButton() async {
+    logTestEvent();
+    await tester.tap(somethingOnPage);
+    await tester.pumpAndSettle();
+  }
+
+  Future<void> verifyScreenIsShown() async {
+    logTestEvent();
+    await tester.pumpUntilFound(find.byType(ExaminationDetailScreen));
+  }
+}

--- a/integration_test/test_sets/prevention/pages/prevention_main_page.dart
+++ b/integration_test/test_sets/prevention/pages/prevention_main_page.dart
@@ -123,7 +123,7 @@ class PreventionPage with BadgeFinders {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(PreventionScreen));
+    await tester.pumpUntilFound(find.byType(PreventionScreen));
   }
 
   void verifyHasPoints(int expectedPoints) {

--- a/integration_test/test_sets/prevention/pages/self_examination/detail/educational_video_page.dart
+++ b/integration_test/test_sets/prevention/pages/self_examination/detail/educational_video_page.dart
@@ -31,7 +31,7 @@ class EducationalVideoPage {
 
   Future<void> verifyVideoIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(video);
+    await tester.pumpUntilFound(video);
   }
 
   void verifySelfExaminationPerformedButtonIsShown() {
@@ -46,6 +46,6 @@ class EducationalVideoPage {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(EducationalVideoScreen));
+    await tester.pumpUntilFound(find.byType(EducationalVideoScreen));
   }
 }

--- a/integration_test/test_sets/prevention/pages/self_examination/detail/has_finding_page.dart
+++ b/integration_test/test_sets/prevention/pages/self_examination/detail/has_finding_page.dart
@@ -36,6 +36,6 @@ class HasFindingPage {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(HasFindingScreen));
+    await tester.pumpUntilFound(find.byType(HasFindingScreen));
   }
 }

--- a/integration_test/test_sets/prevention/pages/self_examination/detail/no_finding_reward_page.dart
+++ b/integration_test/test_sets/prevention/pages/self_examination/detail/no_finding_reward_page.dart
@@ -22,6 +22,6 @@ class NoFindingRewardPage {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(NoFindingScreen));
+    await tester.pumpUntilFound(find.byType(NoFindingScreen));
   }
 }

--- a/integration_test/test_sets/prevention/pages/self_examination/detail/self_examination_detail_page.dart
+++ b/integration_test/test_sets/prevention/pages/self_examination/detail/self_examination_detail_page.dart
@@ -171,6 +171,6 @@ class SelfExaminationDetailPage {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(SelfExaminationDetailScreen));
+    await tester.pumpUntilFound(find.byType(SelfExaminationDetailScreen));
   }
 }

--- a/integration_test/test_sets/prevention/test_cases/self_examination/detail/loon_566_self_exam_detail_male.dart
+++ b/integration_test/test_sets/prevention/test_cases/self_examination/detail/loon_566_self_exam_detail_male.dart
@@ -64,5 +64,5 @@ Future<void> run({
   await selfExaminationDetailPage.verifySelfExamFaqContentIsCollapsed(itemPosition: 2);
 
   await selfExaminationDetailPage.clickBackButton();
-  await tester.pumpUntilVisible(find.byType(PreventionScreen));
+  await tester.pumpUntilFound(find.byType(PreventionScreen));
 }

--- a/integration_test/test_sets/prevention/test_cases/self_examination/detail/loon_567_self_exam_detail_female.dart
+++ b/integration_test/test_sets/prevention/test_cases/self_examination/detail/loon_567_self_exam_detail_female.dart
@@ -65,5 +65,5 @@ Future<void> run({
   await selfExaminationDetailPage.verifySelfExamFaqContentIsCollapsed(itemPosition: 1);
 
   await selfExaminationDetailPage.clickBackButton();
-  await tester.pumpUntilVisible(find.byType(PreventionScreen));
+  await tester.pumpUntilFound(find.byType(PreventionScreen));
 }

--- a/integration_test/test_sets/prevention/test_cases/self_examination/detail/loon_568_self_exam_find_doctor_from_faq_path.dart
+++ b/integration_test/test_sets/prevention/test_cases/self_examination/detail/loon_568_self_exam_find_doctor_from_faq_path.dart
@@ -50,9 +50,9 @@ Future<void> run({
     itemPosition: 1,
     text: 'seznamu lékařů',
   );
-  await tester.pumpUntilVisible(find.byType(FindDoctorScreen));
+  await tester.pumpUntilFound(find.byType(FindDoctorScreen));
   mainScreenPage.verifyBottomBarIsShown();
 
   await mainScreenPage.clickPreventionTab();
-  await tester.pumpUntilVisible(find.byType(PreventionScreen));
+  await tester.pumpUntilFound(find.byType(PreventionScreen));
 }

--- a/integration_test/test_sets/settings/pages/open_settings_page.dart
+++ b/integration_test/test_sets/settings/pages/open_settings_page.dart
@@ -36,6 +36,6 @@ class OpenSettingsPage with SettingsFinders {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(OpenSettingsScreen));
+    await tester.pumpUntilFound(find.byType(OpenSettingsScreen));
   }
 }

--- a/integration_test/test_sets/settings/pages/update_profile/delete_account_page.dart
+++ b/integration_test/test_sets/settings/pages/update_profile/delete_account_page.dart
@@ -65,7 +65,7 @@ class DeleteAccountPage with SettingsFinders {
     logTestEvent();
     await tester.tap(yesBtnDeleteAccountDialog);
     await tester.pumpAndSettle();
-    await tester.pumpUntilNotVisible(yesBtnDeleteAccountDialog);
+    await tester.pumpUntilNotFound(yesBtnDeleteAccountDialog);
   }
 
   Future<void> clickCloseScreenButton() async {

--- a/integration_test/test_sets/settings/pages/update_profile/update_profile_page.dart
+++ b/integration_test/test_sets/settings/pages/update_profile/update_profile_page.dart
@@ -90,7 +90,7 @@ class UpdateProfilePage with SettingsFinders {
     logTestEvent();
     await tester.tap(confirmBtnLogoutDialog);
     await tester.pumpAndSettle();
-    await tester.pumpUntilNotVisible(confirmBtnLogoutDialog);
+    await tester.pumpUntilNotFound(confirmBtnLogoutDialog);
   }
 
   Future<void> closeErrorSheet() async {
@@ -125,6 +125,6 @@ class UpdateProfilePage with SettingsFinders {
 
   Future<void> verifyScreenIsShown() async {
     logTestEvent();
-    await tester.pumpUntilVisible(find.byType(UpdateProfileScreen));
+    await tester.pumpUntilFound(find.byType(UpdateProfileScreen));
   }
 }

--- a/mason-lock.json
+++ b/mason-lock.json
@@ -1,0 +1,1 @@
+{"bricks":{"pom_class":{"path":"bricks/pom_class"}}}

--- a/mason.yaml
+++ b/mason.yaml
@@ -1,0 +1,14 @@
+# Register bricks which can be consumed via the Mason CLI.
+# https://github.com/felangel/mason
+bricks:
+  # To use the template, run `mason make pom_class`.
+  pom_class:
+    path: bricks/pom_class
+
+  # Bricks can also be imported via git url.
+  # Uncomment the following lines to import
+  # a brick from a remote git url.
+  # widget:
+  #   git:
+  #     url: https://github.com/felangel/mason.git
+  #     path: bricks/widget


### PR DESCRIPTION
_Mason CLI allows developers to create and consume reusable templates called bricks powered by the [mason](https://pub.dev/packages/mason) generator._
Dokumentace: https://pub.dev/packages/mason_cli

TLDR: Přidal jsem template generování POM tříd, muselo se to vždy nějak kopírovat. Takhle to i předvyplní některý věci na základě parametrů

Usage je v readme