### PR TITLE
fix(LOON-647): Hide doctors behind bottom sheet

### DIFF
--- a/lib/ui/widgets/find_doctor/map_preview.dart
+++ b/lib/ui/widgets/find_doctor/map_preview.dart
@@ -34,6 +34,7 @@ class MapPreview extends StatelessWidget {
         myLocationEnabled: true,
         myLocationButtonEnabled: false,
         zoomControlsEnabled: false,
+        rotateGesturesEnabled: false,
         onMapCreated: (GoogleMapController mapController) async {
           await mapController.setMapStyle(
             await rootBundle.loadString('assets/maps/map-style.json'),
@@ -50,6 +51,7 @@ class MapPreview extends StatelessWidget {
           // ignore: omit_local_variable_types
           final GoogleMapController controller = await _mapController.future;
           final latLngBounds = await controller.getVisibleRegion();
+
           mapState.setVisibleRegion(latLngBounds);
           mapState.clusterManager.updateMap();
         },


### PR DESCRIPTION
Dávám jako první výstřel k diskuzi. Skrývám doktory za bottom map overlayem ale někdy se ty clustery stejně chovají zvláštně z nějakého jiného důvodu. 
S tímhle řešením by šlo snadno skrývat i doktory za inputem.
Velká nevýhoda tohoto řešení je, že jsem musel vypnout rotaci na mapě. Dopočítávání boundaries na mapě ve spojení s rotací je vyšší dívčí :D WDYT @mzdm je vypnutí rotace velký problém?