### PR TITLE
fix(LOON-627): block from logging in when the server is down

### DIFF
--- a/integration_test/mocks/firebase_auth_mock.dart
+++ b/integration_test/mocks/firebase_auth_mock.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_auth_platform_interface/src/method_channel/method_channel_firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/services.dart';
@@ -8,7 +7,7 @@ import '../test_helpers/method_channels_handlers.dart';
 
 const firebaseAuthChannel = MethodChannelFirebaseAuth.channel;
 
-Future<FirebaseAuth> mockFirebaseAuth() async {
+Future<void> mockFirebaseAuth() async {
   await Firebase.initializeApp();
 
   const username = 'Adam tester';
@@ -53,8 +52,6 @@ Future<FirebaseAuth> mockFirebaseAuth() async {
     }
     return Future<dynamic>.value(response);
   });
-
-  return FirebaseAuth.instance;
 }
 
 void tearDownFirebaseAuth() {

--- a/integration_test/setup.dart
+++ b/integration_test/setup.dart
@@ -3,23 +3,17 @@ import 'dart:async';
 import 'package:charlatan/charlatan.dart';
 import 'package:dio/dio.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:google_sign_in/google_sign_in.dart';
 import 'package:loono/loono.dart';
 import 'package:loono/utils/app_config.dart';
 import 'package:loono/utils/registry.dart';
 
 Future<void> main({
   Dio? dio,
-  FirebaseAuth? firebaseAuth,
-  GoogleSignIn? googleSignIn,
   Map<String, String>? env,
 }) async {
   await setup(
     dioOverride: dio,
-    googleSignIn: googleSignIn,
-    firebaseAuth: firebaseAuth,
     envOverride: env,
     flavor: AppFlavors.dev,
   );
@@ -28,10 +22,7 @@ Future<void> main({
   runApp(const Loono(defaultLocale: 'cs'));
 }
 
-// TODO: pass googleSignIn
 Future<void> runMockApp({
-  FirebaseAuth? firebaseAuthOverride,
-  GoogleSignIn? googleSignIn,
   required Charlatan charlatan,
 }) async {
   final env = {
@@ -43,7 +34,6 @@ Future<void> runMockApp({
   final fakeDio = Dio()..httpClientAdapter = charlatan.toFakeHttpClientAdapter();
   await main(
     dio: fakeDio,
-    firebaseAuth: firebaseAuthOverride,
     env: env,
   );
 }

--- a/integration_test/test_sets/app/flows/login_flow.dart
+++ b/integration_test/test_sets/app/flows/login_flow.dart
@@ -20,6 +20,7 @@ Future<void> loginFlow({
   Account? accountData,
   PreventionStatus? examinationsData,
   CharlatanResponseBuilder? accountResponse,
+  CharlatanResponseBuilder? examinationsResponse,
 }) async {
   final welcomePage = WelcomePage(tester);
   final loginPage = LoginPage(tester);
@@ -37,10 +38,11 @@ Future<void> loginFlow({
     )
     ..whenGet(
       '/examinations',
-      (_) => standardSerializers.serializeWith(
-        PreventionStatus.serializer,
-        examinationsData ?? defaultMaleExaminations,
-      ),
+      examinationsResponse ??
+          (_) => standardSerializers.serializeWith(
+                PreventionStatus.serializer,
+                examinationsData ?? defaultMaleExaminations,
+              ),
     );
 
   await tester.pumpAndSettle();
@@ -50,5 +52,7 @@ Future<void> loginFlow({
   await loginPage.verifyScreenIsShown();
 
   await loginPage.loginWithGoogle();
-  if (accountResponse == null) await preventionPage.verifyScreenIsShown();
+  if (accountResponse == null && examinationsResponse == null) {
+    await preventionPage.verifyScreenIsShown();
+  }
 }

--- a/integration_test/test_sets/app/test_cases/loon_580_force_update.dart
+++ b/integration_test/test_sets/app/test_cases/loon_580_force_update.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:loono/utils/registry.dart';
@@ -12,11 +11,10 @@ import '../pages/force_update_page.dart';
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(
     tester: tester,
     charlatan: charlatan,

--- a/integration_test/test_sets/app_test.dart
+++ b/integration_test/test_sets/app_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -53,11 +52,10 @@ void main() {
   group('App', () {
     group('Force update feature', () {
       late Charlatan charlatan;
-      late FirebaseAuth firebaseAuth;
 
       setUp(() async {
         mockGoogleSignIn();
-        firebaseAuth = await mockFirebaseAuth();
+        await mockFirebaseAuth();
         charlatan = Charlatan();
       });
 
@@ -67,8 +65,7 @@ void main() {
 
       testWidgets(
         'TC(LOON-580): Force update - routing is blocked',
-        (tester) async =>
-            loon580.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+        (tester) async => loon580.run(tester: tester, charlatan: charlatan),
       );
     });
   });
@@ -134,11 +131,10 @@ void main() {
   group('Settings', () {
     group('Delete Account', () {
       late Charlatan charlatan;
-      late FirebaseAuth firebaseAuth;
 
       setUp(() async {
         mockGoogleSignIn();
-        firebaseAuth = await mockFirebaseAuth();
+        await mockFirebaseAuth();
         charlatan = Charlatan();
       });
 
@@ -148,30 +144,26 @@ void main() {
 
       testWidgets(
         'TC(LOON-465): Delete Account & Contact Loono support (straight path)',
-        (tester) async =>
-            loon465.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+        (tester) async => loon465.run(tester: tester, charlatan: charlatan),
       );
 
       testWidgets(
         'TC(LOON-466): Delete Account - canceling process (path 1)',
-        (tester) async =>
-            loon466.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+        (tester) async => loon466.run(tester: tester, charlatan: charlatan),
       );
 
       testWidgets(
         'TC(LOON-467): Delete Account - canceling process (path 2)',
-        (tester) async =>
-            loon467.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+        (tester) async => loon467.run(tester: tester, charlatan: charlatan),
       );
     });
 
     group('Logout', () {
       late Charlatan charlatan;
-      late FirebaseAuth firebaseAuth;
 
       setUp(() async {
         mockGoogleSignIn();
-        firebaseAuth = await mockFirebaseAuth();
+        await mockFirebaseAuth();
         charlatan = Charlatan();
       });
 
@@ -181,30 +173,26 @@ void main() {
 
       testWidgets(
         'TC(LOON-437): Logout (straight path)',
-        (tester) async =>
-            loon437.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+        (tester) async => loon437.run(tester: tester, charlatan: charlatan),
       );
 
       testWidgets(
         'TC(LOON-438): Logout (cancelling process)',
-        (tester) async =>
-            loon438.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+        (tester) async => loon438.run(tester: tester, charlatan: charlatan),
       );
 
       testWidgets(
         'TC(LOON-439): Logout (re-logging after successful logout)',
-        (tester) async =>
-            loon439.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+        (tester) async => loon439.run(tester: tester, charlatan: charlatan),
       );
     });
 
     group('Update profile', () {
       late Charlatan charlatan;
-      late FirebaseAuth firebaseAuth;
 
       setUp(() async {
         mockGoogleSignIn();
-        firebaseAuth = await mockFirebaseAuth();
+        await mockFirebaseAuth();
         charlatan = Charlatan();
       });
 
@@ -214,38 +202,33 @@ void main() {
 
       testWidgets(
         'TC(LOON-554): Updating profile information - Positive scenario',
-        (tester) async =>
-            loon554.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+        (tester) async => loon554.run(tester: tester, charlatan: charlatan),
       );
 
       testWidgets(
         'TC(LOON-555): Updating profile information - Negative scenario',
-        (tester) async =>
-            loon555.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+        (tester) async => loon555.run(tester: tester, charlatan: charlatan),
       );
 
       testWidgets(
         'TC(LOON-435): Update profile (photo actions) - Positive scenario',
-        (tester) async =>
-            loon435.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+        (tester) async => loon435.run(tester: tester, charlatan: charlatan),
         skip: true,
       );
 
       testWidgets(
         'TC(LOON-436): Update profile (photo actions) - Negative scenario',
-        (tester) async =>
-            loon436.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+        (tester) async => loon436.run(tester: tester, charlatan: charlatan),
         skip: true,
       );
     });
 
     group('Points', () {
       late Charlatan charlatan;
-      late FirebaseAuth firebaseAuth;
 
       setUp(() async {
         mockGoogleSignIn();
-        firebaseAuth = await mockFirebaseAuth();
+        await mockFirebaseAuth();
         charlatan = Charlatan();
       });
 
@@ -255,19 +238,17 @@ void main() {
 
       testWidgets(
         'TC(LOON-464): View Points & Leaderboard',
-        (tester) async =>
-            loon464.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+        (tester) async => loon464.run(tester: tester, charlatan: charlatan),
       );
     });
   });
 
   group('Prevention', () {
     late Charlatan charlatan;
-    late FirebaseAuth firebaseAuth;
 
     setUp(() async {
       mockGoogleSignIn();
-      firebaseAuth = await mockFirebaseAuth();
+      await mockFirebaseAuth();
       charlatan = Charlatan();
     });
 
@@ -283,54 +264,46 @@ void main() {
       group('Perform Self Examination', () {
         testWidgets(
           'TC(LOON-565):  Performing self-examination - Has finding - find doctor path',
-          (tester) async =>
-              loon565.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+          (tester) async => loon565.run(tester: tester, charlatan: charlatan),
         );
 
         testWidgets(
           'TC(LOON-564): Performing self-examination - Has finding - closing process path',
-          (tester) async =>
-              loon564.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+          (tester) async => loon564.run(tester: tester, charlatan: charlatan),
         );
       });
 
       group('Detail', () {
         testWidgets(
           'TC(LOON-568): View details of self-examination - Find doctor from FAQ section path',
-          (tester) async =>
-              loon568.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+          (tester) async => loon568.run(tester: tester, charlatan: charlatan),
         );
 
         testWidgets(
           'TC(LOON-567): View details of self-examination - Female',
-          (tester) async =>
-              loon567.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+          (tester) async => loon567.run(tester: tester, charlatan: charlatan),
         );
 
         testWidgets(
           'TC(LOON-566): View details of self-examination - Male',
-          (tester) async =>
-              loon566.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+          (tester) async => loon566.run(tester: tester, charlatan: charlatan),
         );
       });
 
       group('Educational Video', () {
         testWidgets(
           'TC(LOON-561): Educational Video - active self-examination path',
-          (tester) async =>
-              loon561.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+          (tester) async => loon561.run(tester: tester, charlatan: charlatan),
         );
 
         testWidgets(
           'TC(LOON-562): Educational Video - inactive self-examination path',
-          (tester) async =>
-              loon562.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+          (tester) async => loon562.run(tester: tester, charlatan: charlatan),
         );
 
         testWidgets(
           'TC(LOON-563): Educational Video - closing process path',
-          (tester) async =>
-              loon563.run(tester: tester, charlatan: charlatan, firebaseAuth: firebaseAuth),
+          (tester) async => loon563.run(tester: tester, charlatan: charlatan),
         );
       });
     });

--- a/integration_test/test_sets/app_test.dart
+++ b/integration_test/test_sets/app_test.dart
@@ -10,6 +10,7 @@ import '../mocks/google_sign_in_mock.dart';
 import '../test_helpers/post_app_clear.dart';
 import 'app/test_cases/loon_580_force_update.dart' as loon580;
 import 'onboarding/test_cases/other/loon_542_installing_and_opening_app.dart' as loon542;
+import 'onboarding/test_cases/other/loon_671_login_server_down_block_user.dart' as loon671;
 import 'onboarding/test_cases/questionnaire/loon_543_male_onboarding_flow.dart' as loon543;
 import 'onboarding/test_cases/questionnaire/loon_544_female_onboarding_flow.dart' as loon544;
 import 'onboarding/test_cases/questionnaire/loon_558_onboarding_age_validation.dart' as loon558;
@@ -107,8 +108,10 @@ void main() {
     group('Other', () {
       late Charlatan charlatan;
 
-      setUp(() {
+      setUp(() async {
         charlatan = Charlatan();
+        mockGoogleSignIn();
+        await mockFirebaseAuth();
       });
 
       tearDown(() async {
@@ -119,6 +122,11 @@ void main() {
         'TC(LOON-542): Installing & opening app - Intro & Pre-auth Main Screen routes',
         (tester) async => loon542.run(tester: tester, charlatan: charlatan),
         timeout: const Timeout(Duration(minutes: 2)),
+      );
+
+      testWidgets(
+        'TC(LOON-671): Blocking the user from logging in when the server is down',
+        (tester) async => loon671.run(tester: tester, charlatan: charlatan),
       );
     });
   });

--- a/integration_test/test_sets/onboarding/test_cases/other/loon_671_login_server_down_block_user.dart
+++ b/integration_test/test_sets/onboarding/test_cases/other/loon_671_login_server_down_block_user.dart
@@ -1,0 +1,31 @@
+import 'package:charlatan/charlatan.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import '../../../../setup.dart' as app;
+import '../../../../test_helpers/widget_tester_extensions.dart';
+import '../../../app/flows/login_flow.dart';
+import '../../../app/pages/login_page.dart';
+
+/// [Test case link](https://cesko-digital.atlassian.net/browse/LOON-671)
+Future<void> run({
+  required WidgetTester tester,
+  required Charlatan charlatan,
+}) async {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  final loginPage = LoginPage(tester);
+
+  await app.runMockApp(charlatan: charlatan);
+  await loginFlow(
+    tester: tester,
+    charlatan: charlatan,
+    examinationsResponse: (_) => CharlatanHttpResponse(statusCode: 500),
+  );
+
+  // Server is down, an error message is shown to the user and user stays on the same (Login) page.
+  const errorMsg = 'Naše systémy mají preventivní prohlídku';
+  await tester.pumpUntilFound(find.textContaining(errorMsg));
+  await tester.pumpUntilNotFound(find.textContaining(errorMsg));
+  await loginPage.verifyScreenIsShown();
+}

--- a/integration_test/test_sets/prevention/test_cases/self_examination/detail/loon_566_self_exam_detail_male.dart
+++ b/integration_test/test_sets/prevention/test_cases/self_examination/detail/loon_566_self_exam_detail_male.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:loono_api/loono_api.dart';
@@ -14,14 +13,13 @@ import '../../../pages/self_examination/detail/self_examination_detail_page.dart
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   final preventionPage = PreventionPage(tester);
   final selfExaminationDetailPage = SelfExaminationDetailPage(tester);
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(
     tester: tester,
     charlatan: charlatan,

--- a/integration_test/test_sets/prevention/test_cases/self_examination/detail/loon_567_self_exam_detail_female.dart
+++ b/integration_test/test_sets/prevention/test_cases/self_examination/detail/loon_567_self_exam_detail_female.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:loono_api/loono_api.dart';
@@ -14,14 +13,13 @@ import '../../../pages/self_examination/detail/self_examination_detail_page.dart
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   final preventionPage = PreventionPage(tester);
   final selfExaminationDetailPage = SelfExaminationDetailPage(tester);
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(
     tester: tester,
     charlatan: charlatan,

--- a/integration_test/test_sets/prevention/test_cases/self_examination/detail/loon_568_self_exam_find_doctor_from_faq_path.dart
+++ b/integration_test/test_sets/prevention/test_cases/self_examination/detail/loon_568_self_exam_find_doctor_from_faq_path.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:loono_api/loono_api.dart';
@@ -16,7 +15,6 @@ import '../../../pages/self_examination/detail/self_examination_detail_page.dart
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -25,7 +23,7 @@ Future<void> run({
   final findDoctorPage = FindDoctorPage(tester);
   final mainScreenPage = PostAuthMainScreenPage(tester);
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(
     tester: tester,
     charlatan: charlatan,

--- a/integration_test/test_sets/prevention/test_cases/self_examination/educational_video/loon_561_educational_video_active_path.dart
+++ b/integration_test/test_sets/prevention/test_cases/self_examination/educational_video/loon_561_educational_video_active_path.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:loono_api/loono_api.dart';
@@ -16,7 +15,6 @@ import '../../../pages/self_examination/detail/self_examination_detail_page.dart
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -25,7 +23,7 @@ Future<void> run({
   final educationalVideoPage = EducationalVideoPage(tester);
   final howItWentModalPage = HowItWentModalPage(tester);
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(
     tester: tester,
     charlatan: charlatan,

--- a/integration_test/test_sets/prevention/test_cases/self_examination/educational_video/loon_562_educational_video_inactive_path.dart
+++ b/integration_test/test_sets/prevention/test_cases/self_examination/educational_video/loon_562_educational_video_inactive_path.dart
@@ -1,6 +1,5 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:loono_api/loono_api.dart';
@@ -17,7 +16,6 @@ import '../../../pages/self_examination/detail/self_examination_detail_page.dart
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -25,7 +23,7 @@ Future<void> run({
   final selfExaminationDetailPage = SelfExaminationDetailPage(tester);
   final educationalVideoPage = EducationalVideoPage(tester);
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   final selfExam = defaultFemaleExaminations.selfexaminations.first.rebuild(
     (b) => b
       ..plannedDate = DateTime.now().add(const Duration(days: 10)).toDate()

--- a/integration_test/test_sets/prevention/test_cases/self_examination/educational_video/loon_563_educational_video_closing_process_path.dart
+++ b/integration_test/test_sets/prevention/test_cases/self_examination/educational_video/loon_563_educational_video_closing_process_path.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:loono_api/loono_api.dart';
@@ -15,7 +14,6 @@ import '../../../pages/self_examination/detail/self_examination_detail_page.dart
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -23,7 +21,7 @@ Future<void> run({
   final selfExaminationDetailPage = SelfExaminationDetailPage(tester);
   final educationalVideoPage = EducationalVideoPage(tester);
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(
     tester: tester,
     charlatan: charlatan,

--- a/integration_test/test_sets/prevention/test_cases/self_examination/perform_self_examination/loon_564_perform_self_exam_has_finding_closing_process_path.dart
+++ b/integration_test/test_sets/prevention/test_cases/self_examination/perform_self_examination/loon_564_perform_self_exam_has_finding_closing_process_path.dart
@@ -1,6 +1,5 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:loono_api/loono_api.dart';
@@ -19,7 +18,6 @@ import '../../../pages/self_examination/detail/self_examination_detail_page.dart
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -29,7 +27,7 @@ Future<void> run({
   final howItWentModalPage = HowItWentModalPage(tester);
   final hasFindingPage = HasFindingPage(tester);
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(
     tester: tester,
     charlatan: charlatan,

--- a/integration_test/test_sets/prevention/test_cases/self_examination/perform_self_examination/loon_565_perform_self_exam_has_finding_find_doctor_path.dart
+++ b/integration_test/test_sets/prevention/test_cases/self_examination/perform_self_examination/loon_565_perform_self_exam_has_finding_find_doctor_path.dart
@@ -1,6 +1,5 @@
 import 'package:built_collection/built_collection.dart';
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:loono_api/loono_api.dart';
@@ -20,7 +19,6 @@ import '../../../pages/self_examination/detail/self_examination_detail_page.dart
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -31,7 +29,7 @@ Future<void> run({
   final hasFindingPage = HasFindingPage(tester);
   final findDoctorPage = FindDoctorPage(tester);
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(
     tester: tester,
     charlatan: charlatan,

--- a/integration_test/test_sets/settings/test_cases/delete_account/loon_465_delete_account_and_contact_straight_path.dart
+++ b/integration_test/test_sets/settings/test_cases/delete_account/loon_465_delete_account_and_contact_straight_path.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -15,11 +14,10 @@ import '../../pages/update_profile/update_profile_page.dart';
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(tester: tester, charlatan: charlatan);
 
   final preventionPage = PreventionPage(tester);

--- a/integration_test/test_sets/settings/test_cases/delete_account/loon_466_delete_account_cancelling_proccess.dart
+++ b/integration_test/test_sets/settings/test_cases/delete_account/loon_466_delete_account_cancelling_proccess.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -14,11 +13,10 @@ import '../../pages/update_profile/update_profile_page.dart';
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(tester: tester, charlatan: charlatan);
 
   final preventionPage = PreventionPage(tester);

--- a/integration_test/test_sets/settings/test_cases/delete_account/loon_467_delete_account_cancelling_proccess_path_2.dart
+++ b/integration_test/test_sets/settings/test_cases/delete_account/loon_467_delete_account_cancelling_proccess_path_2.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -14,10 +13,9 @@ import '../../pages/update_profile/update_profile_page.dart';
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(tester: tester, charlatan: charlatan);
 
   final preventionPage = PreventionPage(tester);

--- a/integration_test/test_sets/settings/test_cases/logout/loon_437_logout_straight_path.dart
+++ b/integration_test/test_sets/settings/test_cases/logout/loon_437_logout_straight_path.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -14,11 +13,10 @@ import '../../pages/update_profile/update_profile_page.dart';
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(tester: tester, charlatan: charlatan);
 
   final preventionPage = PreventionPage(tester);

--- a/integration_test/test_sets/settings/test_cases/logout/loon_438_logout_cancelling_process.dart
+++ b/integration_test/test_sets/settings/test_cases/logout/loon_438_logout_cancelling_process.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -13,11 +12,10 @@ import '../../pages/update_profile/update_profile_page.dart';
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(tester: tester, charlatan: charlatan);
 
   final preventionPage = PreventionPage(tester);

--- a/integration_test/test_sets/settings/test_cases/logout/loon_439_logout_relogging.dart
+++ b/integration_test/test_sets/settings/test_cases/logout/loon_439_logout_relogging.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -16,11 +15,10 @@ import '../../pages/update_profile/update_profile_page.dart';
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   await loginFlow(tester: tester, charlatan: charlatan);
 
   final preventionPage = PreventionPage(tester);

--- a/integration_test/test_sets/settings/test_cases/points/loon_464_view_points_and_leaderboard.dart
+++ b/integration_test/test_sets/settings/test_cases/points/loon_464_view_points_and_leaderboard.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:loono_api/loono_api.dart';
@@ -20,11 +19,10 @@ part '../../test_data/loon_464_test_data.dart';
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   charlatan.whenGet('/providers/all', (_) => HEALTHCARE_PROVIDER_ENCODED);
   await loginFlow(tester: tester, charlatan: charlatan);
 

--- a/integration_test/test_sets/settings/test_cases/update_profile/loon_435_update_photo_positive_scenario.dart
+++ b/integration_test/test_sets/settings/test_cases/update_profile/loon_435_update_photo_positive_scenario.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -11,11 +10,10 @@ import '../../../app/test_data/fake_healthcare_provider_response.dart';
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   charlatan.whenGet('/providers/all', (_) => HEALTHCARE_PROVIDER_ENCODED);
 
   await loginFlow(tester: tester, charlatan: charlatan);

--- a/integration_test/test_sets/settings/test_cases/update_profile/loon_436_update_photo_negative_scenario.dart
+++ b/integration_test/test_sets/settings/test_cases/update_profile/loon_436_update_photo_negative_scenario.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -11,11 +10,10 @@ import '../../../app/test_data/fake_healthcare_provider_response.dart';
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   charlatan.whenGet('/providers/all', (_) => HEALTHCARE_PROVIDER_ENCODED);
 
   await loginFlow(tester: tester, charlatan: charlatan);

--- a/integration_test/test_sets/settings/test_cases/update_profile/loon_554_update_profile_positive_scenario.dart
+++ b/integration_test/test_sets/settings/test_cases/update_profile/loon_554_update_profile_positive_scenario.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:loono_api/loono_api.dart';
@@ -20,11 +19,10 @@ part '../../test_data/loon_554_test_data.dart';
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   charlatan.whenGet('/providers/all', (_) => HEALTHCARE_PROVIDER_ENCODED);
 
   await loginFlow(tester: tester, charlatan: charlatan);

--- a/integration_test/test_sets/settings/test_cases/update_profile/loon_555_update_profile_negative_scenario.dart
+++ b/integration_test/test_sets/settings/test_cases/update_profile/loon_555_update_profile_negative_scenario.dart
@@ -1,5 +1,4 @@
 import 'package:charlatan/charlatan.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -19,11 +18,10 @@ part '../../test_data/loon_555_test_data.dart';
 Future<void> run({
   required WidgetTester tester,
   required Charlatan charlatan,
-  required FirebaseAuth firebaseAuth,
 }) async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  await app.runMockApp(firebaseAuthOverride: firebaseAuth, charlatan: charlatan);
+  await app.runMockApp(charlatan: charlatan);
   charlatan.whenGet('/providers/all', (_) => HEALTHCARE_PROVIDER_ENCODED);
 
   await loginFlow(tester: tester, charlatan: charlatan);

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -1019,5 +1019,7 @@
   "feedback_form_support_text": "Potřebuješ poradit? Neváhej nás kontaktovat na ",
   "@feedback_form_support_text": {},
   "feedback_form_success_message": "Odesláno. Děkujeme za zpětnou vazbu!",
-  "@feedback_form_success_message": {}
+  "@feedback_form_success_message": {},
+  "login_server_down_message": "Naše systémy mají preventivní prohlídku, zkus to znovu za 5 minut.",
+  "@login_server_down_message": {}
 }

--- a/lib/loono.dart
+++ b/lib/loono.dart
@@ -37,6 +37,9 @@ class Loono extends StatelessWidget {
       builder: (context, snapshot) {
         final authUser = snapshot.data;
         if (authUser == null &&
+            !_appRouter.isRouteActive(EmailRoute.name) &&
+            !_appRouter.isRouteActive(OnboardingFormDoneRoute.name) &&
+            !_appRouter.isRouteActive(LoginRoute.name) &&
             !_appRouter.isRouteActive(LogoutRoute.name) &&
             !_appRouter.isRouteActive(AfterDeletionRoute.name)) {
           SchedulerBinding.instance?.addPostFrameCallback((_) {

--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -18,12 +18,10 @@ import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 class AuthService {
   AuthService({
     required api.LoonoApi api,
-    required FirebaseAuth firebaseAuth,
-    required GoogleSignIn googleSignIn,
     required SecureStorageService secureStorageService,
   })  : _api = api,
-        _auth = firebaseAuth,
-        _googleSignIn = googleSignIn,
+        _auth = FirebaseAuth.instance,
+        _googleSignIn = GoogleSignIn(),
         _secureStorage = secureStorageService {
     _auth.authStateChanges().listen((authUser) async {
       if (authUser == null) {

--- a/lib/services/examinations_service.dart
+++ b/lib/services/examinations_service.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 
 import 'package:flutter/material.dart';
+import 'package:loono/models/api_response.dart';
 import 'package:loono/services/api_service.dart';
 import 'package:loono/utils/registry.dart';
 import 'package:loono_api/loono_api.dart';
@@ -9,25 +10,25 @@ class ExaminationsProvider extends ChangeNotifier {
   PreventionStatus? examinations;
   bool loading = false;
 
-  Future<void> fetchExaminations() async {
+  Future<ApiResponse<PreventionStatus>> fetchExaminations() async {
     log('fetching examinations from server');
 
     loading = true;
     notifyListeners();
 
-    await registry.get<ApiService>().getExaminations().then((res) {
-      res.map(
-        success: (exams) {
-          examinations = exams.data;
-          loading = false;
-        },
-        failure: (err) {
-          loading = false;
-        },
-      );
-    });
+    final examResponse = await registry.get<ApiService>().getExaminations();
+    examResponse.map(
+      success: (exams) {
+        examinations = exams.data;
+        loading = false;
+      },
+      failure: (err) {
+        loading = false;
+      },
+    );
 
     notifyListeners();
+    return examResponse;
   }
 
   void clearExaminations() {

--- a/lib/ui/screens/main/pre_auth/login.dart
+++ b/lib/ui/screens/main/pre_auth/login.dart
@@ -1,22 +1,28 @@
 import 'dart:io' show Platform;
 
 import 'package:auto_route/auto_route.dart';
+import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' as s;
 import 'package:flutter_svg/svg.dart';
 import 'package:loono/constants.dart';
 import 'package:loono/helpers/flushbar_message.dart';
 import 'package:loono/helpers/onboarding_state_helpers.dart';
+import 'package:loono/helpers/social_login_helpers.dart';
 import 'package:loono/helpers/ui_helpers.dart';
 import 'package:loono/l10n/ext.dart';
+import 'package:loono/models/firebase_user.dart';
 import 'package:loono/repositories/user_repository.dart';
 import 'package:loono/router/app_router.gr.dart';
 import 'package:loono/services/auth/auth_service.dart';
 import 'package:loono/services/auth/failures.dart';
 import 'package:loono/services/database_service.dart';
+import 'package:loono/services/examinations_service.dart';
 import 'package:loono/ui/widgets/social_login_button.dart';
 import 'package:loono/utils/app_config.dart';
 import 'package:loono/utils/registry.dart';
+import 'package:modal_progress_hud_nsn/modal_progress_hud_nsn.dart';
+import 'package:provider/provider.dart';
 import 'package:yaml/yaml.dart';
 
 class LoginScreen extends StatelessWidget {
@@ -26,130 +32,162 @@ class LoginScreen extends StatelessWidget {
   final _examinationQuestionnairesDao = registry.get<DatabaseService>().examinationQuestionnaires;
   final _userRepository = registry.get<UserRepository>();
 
+  final ValueNotifier<bool> _isLoading = ValueNotifier(false);
+
+  void _setLoadingState(bool value) => _isLoading.value = value;
+
   @override
   Widget build(BuildContext context) {
     final isScreenSmall = LoonoSizes.isScreenSmall(context);
-    return Scaffold(
-      body: SafeArea(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Expanded(
-              child: SizedBox(
+    return ValueListenableBuilder<bool>(
+        valueListenable: _isLoading,
+        builder: (context, isLoadingValue, _) {
+          return ModalProgressHUD(
+            inAsyncCall: isLoadingValue,
+            progressIndicator: const CircularProgressIndicator(color: LoonoColors.primaryEnabled),
+            opacity: 0.5,
+            child: Scaffold(
+              body: SafeArea(
                 child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    const SizedBox(height: 30),
-                    if (!isScreenSmall && registry.get<AppConfig>().flavor == AppFlavors.dev) ...[
-                      TextButton(
-                        onPressed: () async {
-                          final data = await s.rootBundle.loadString('assets/supported_apis.yaml');
-                          final apis = loadYaml(data) as YamlList;
+                    Expanded(
+                      child: SizedBox(
+                        child: Column(
+                          children: [
+                            const SizedBox(height: 30),
+                            if (!isScreenSmall &&
+                                registry.get<AppConfig>().flavor == AppFlavors.dev) ...[
+                              TextButton(
+                                onPressed: () async {
+                                  final data =
+                                      await s.rootBundle.loadString('assets/supported_apis.yaml');
+                                  final apis = loadYaml(data) as YamlList;
 
-                          await showDialog<void>(
-                            context: context,
-                            barrierDismissible: false, // user must tap button!
-                            builder: (BuildContext context) {
-                              return AlertDialog(
-                                title: const Text('Select API'),
-                                content: SingleChildScrollView(
-                                  child: ListBody(
-                                    children: apis.nodes
-                                        .map(
-                                          (dynamic api) => ElevatedButton(
-                                            onPressed: () async {
-                                              await registry
-                                                  .get<AuthService>()
-                                                  .switchApi(api['url'].toString());
-                                              await AutoRouter.of(context).pop();
-                                            },
-                                            child: Text(api['url'].toString()),
+                                  await showDialog<void>(
+                                    context: context,
+                                    barrierDismissible: false, // user must tap button!
+                                    builder: (BuildContext context) {
+                                      return AlertDialog(
+                                        title: const Text('Select API'),
+                                        content: SingleChildScrollView(
+                                          child: ListBody(
+                                            children: apis.nodes
+                                                .map(
+                                                  (dynamic api) => ElevatedButton(
+                                                    onPressed: () async {
+                                                      await registry
+                                                          .get<AuthService>()
+                                                          .switchApi(api['url'].toString());
+                                                      await AutoRouter.of(context).pop();
+                                                    },
+                                                    child: Text(api['url'].toString()),
+                                                  ),
+                                                )
+                                                .toList(),
                                           ),
-                                        )
-                                        .toList(),
+                                        ),
+                                      );
+                                    },
+                                  );
+                                },
+                                child: const Text('switch api (dev flavour only)'),
+                              ),
+                              const SizedBox(height: 10),
+                            ],
+                            Padding(
+                              padding: const EdgeInsets.symmetric(horizontal: 18.0),
+                              child: Align(
+                                alignment: Alignment.centerLeft,
+                                child: Text(
+                                  context.l10n.login_header,
+                                  textAlign: TextAlign.left,
+                                  style: LoonoSizes.responsiveStyleScale(
+                                    context,
+                                    LoonoFonts.headerFontStyle,
                                   ),
                                 ),
-                              );
-                            },
-                          );
-                        },
-                        child: const Text('switch api (dev flavour only)'),
-                      ),
-                      const SizedBox(height: 10),
-                    ],
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 18.0),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          context.l10n.login_header,
-                          textAlign: TextAlign.left,
-                          style: LoonoSizes.responsiveStyleScale(
-                            context,
-                            LoonoFonts.headerFontStyle,
-                          ),
+                              ),
+                            ),
+                            Expanded(child: SvgPicture.asset('assets/icons/carousel_doctors.svg')),
+                          ],
                         ),
                       ),
                     ),
-                    Expanded(child: SvgPicture.asset('assets/icons/carousel_doctors.svg')),
+                    if (isScreenSmall) const SizedBox(height: 10),
+                    if (Platform.isIOS) ...[
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 18.0),
+                        child: SocialLoginButton.apple(
+                          onPressed: () async => _processSocialLogin(context,
+                              socialLoginMethod: SocialLoginMethod.apple),
+                        ),
+                      ),
+                      const SizedBox(height: 20.0),
+                    ],
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 18.0),
+                      child: SocialLoginButton.google(
+                        onPressed: () async => _processSocialLogin(context,
+                            socialLoginMethod: SocialLoginMethod.google),
+                      ),
+                    ),
+                    if (!isScreenSmall) const SizedBox(height: 10),
+                    TextButton(
+                      onPressed: () async {
+                        final questionnaires = await _examinationQuestionnairesDao.getAll();
+                        if (questionnaires.isOnboardingDone) {
+                          await AutoRouter.of(context).push(PreAuthMainRoute());
+                        } else {
+                          await AutoRouter.of(context).push(const OnboardingWrapperRoute());
+                        }
+                      },
+                      child: Text(
+                        context.l10n.login_create_new_account,
+                        style: LoonoFonts.paragraphFontStyle,
+                      ),
+                    ),
+                    if (!isScreenSmall) const SizedBox(height: 10),
                   ],
                 ),
               ),
             ),
-            if (isScreenSmall) const SizedBox(height: 10),
-            if (Platform.isIOS) ...[
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 18.0),
-                child: SocialLoginButton.apple(
-                  onPressed: () async {
-                    final accountExistsResult =
-                        await _authService.checkAppleAccountExistsAndSignIn();
-                    accountExistsResult.fold(
-                      (failure) => showFlushBarError(context, failure.getMessage(context)),
-                      (authUser) async {
-                        await _userRepository.createUserIfNotExists();
-                        await AutoRouter.of(context).replaceAll([const MainScreenRouter()]);
-                      },
-                    );
-                  },
-                ),
-              ),
-              const SizedBox(height: 20.0),
-            ],
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 18.0),
-              child: SocialLoginButton.google(
-                onPressed: () async {
-                  final accountExistsResult =
-                      await _authService.checkGoogleAccountExistsAndSignIn();
-                  accountExistsResult.fold(
-                    (failure) => showFlushBarError(context, failure.getMessage(context)),
-                    (authUser) async {
-                      await _userRepository.createUserIfNotExists();
-                      await AutoRouter.of(context).replaceAll([const MainScreenRouter()]);
-                    },
-                  );
+          );
+        });
+  }
+
+  Future<void> _processSocialLogin(
+    BuildContext context, {
+    required SocialLoginMethod socialLoginMethod,
+  }) async {
+    final Either<AuthFailure, AuthUser> accountExistsResult;
+    switch (socialLoginMethod) {
+      case SocialLoginMethod.apple:
+        accountExistsResult = await _authService.checkAppleAccountExistsAndSignIn();
+        break;
+      case SocialLoginMethod.google:
+        accountExistsResult = await _authService.checkGoogleAccountExistsAndSignIn();
+        break;
+    }
+    accountExistsResult.fold(
+      (failure) => showFlushBarError(context, failure.getMessage(context)),
+      (authUser) async {
+        _setLoadingState(true);
+        await context.read<ExaminationsProvider>().fetchExaminations().then(
+              (res) async => res.when(
+                success: (data) async {
+                  // An account with this email already exists, proceed through the login.
+                  await _userRepository.createUser();
+                  await AutoRouter.of(context).replaceAll([const MainScreenRouter()]);
+                },
+                failure: (_) async {
+                  showFlushBarError(context, context.l10n.login_server_down_message);
+                  await _authService.signOut();
                 },
               ),
-            ),
-            if (!isScreenSmall) const SizedBox(height: 10),
-            TextButton(
-              onPressed: () async {
-                final questionnaires = await _examinationQuestionnairesDao.getAll();
-                if (questionnaires.isOnboardingDone) {
-                  await AutoRouter.of(context).push(PreAuthMainRoute());
-                } else {
-                  await AutoRouter.of(context).push(const OnboardingWrapperRoute());
-                }
-              },
-              child: Text(
-                context.l10n.login_create_new_account,
-                style: LoonoFonts.paragraphFontStyle,
-              ),
-            ),
-            if (!isScreenSmall) const SizedBox(height: 10),
-          ],
-        ),
-      ),
+            );
+        _setLoadingState(false);
+      },
     );
   }
 }

--- a/lib/ui/screens/main/pre_auth/login.dart
+++ b/lib/ui/screens/main/pre_auth/login.dart
@@ -40,120 +40,125 @@ class LoginScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final isScreenSmall = LoonoSizes.isScreenSmall(context);
     return ValueListenableBuilder<bool>(
-        valueListenable: _isLoading,
-        builder: (context, isLoadingValue, _) {
-          return ModalProgressHUD(
-            inAsyncCall: isLoadingValue,
-            progressIndicator: const CircularProgressIndicator(color: LoonoColors.primaryEnabled),
-            opacity: 0.5,
-            child: Scaffold(
-              body: SafeArea(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Expanded(
-                      child: SizedBox(
-                        child: Column(
-                          children: [
-                            const SizedBox(height: 30),
-                            if (!isScreenSmall &&
-                                registry.get<AppConfig>().flavor == AppFlavors.dev) ...[
-                              TextButton(
-                                onPressed: () async {
-                                  final data =
-                                      await s.rootBundle.loadString('assets/supported_apis.yaml');
-                                  final apis = loadYaml(data) as YamlList;
+      valueListenable: _isLoading,
+      builder: (context, isLoadingValue, _) {
+        return ModalProgressHUD(
+          inAsyncCall: isLoadingValue,
+          progressIndicator: const CircularProgressIndicator(color: LoonoColors.primaryEnabled),
+          opacity: 0.5,
+          child: Scaffold(
+            body: SafeArea(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Expanded(
+                    child: SizedBox(
+                      child: Column(
+                        children: [
+                          const SizedBox(height: 30),
+                          if (!isScreenSmall &&
+                              registry.get<AppConfig>().flavor == AppFlavors.dev) ...[
+                            TextButton(
+                              onPressed: () async {
+                                final data =
+                                    await s.rootBundle.loadString('assets/supported_apis.yaml');
+                                final apis = loadYaml(data) as YamlList;
 
-                                  await showDialog<void>(
-                                    context: context,
-                                    barrierDismissible: false, // user must tap button!
-                                    builder: (BuildContext context) {
-                                      return AlertDialog(
-                                        title: const Text('Select API'),
-                                        content: SingleChildScrollView(
-                                          child: ListBody(
-                                            children: apis.nodes
-                                                .map(
-                                                  (dynamic api) => ElevatedButton(
-                                                    onPressed: () async {
-                                                      await registry
-                                                          .get<AuthService>()
-                                                          .switchApi(api['url'].toString());
-                                                      await AutoRouter.of(context).pop();
-                                                    },
-                                                    child: Text(api['url'].toString()),
-                                                  ),
-                                                )
-                                                .toList(),
-                                          ),
+                                await showDialog<void>(
+                                  context: context,
+                                  barrierDismissible: false, // user must tap button!
+                                  builder: (BuildContext context) {
+                                    return AlertDialog(
+                                      title: const Text('Select API'),
+                                      content: SingleChildScrollView(
+                                        child: ListBody(
+                                          children: apis.nodes
+                                              .map(
+                                                (dynamic api) => ElevatedButton(
+                                                  onPressed: () async {
+                                                    await registry
+                                                        .get<AuthService>()
+                                                        .switchApi(api['url'].toString());
+                                                    await AutoRouter.of(context).pop();
+                                                  },
+                                                  child: Text(api['url'].toString()),
+                                                ),
+                                              )
+                                              .toList(),
                                         ),
-                                      );
-                                    },
-                                  );
-                                },
-                                child: const Text('switch api (dev flavour only)'),
-                              ),
-                              const SizedBox(height: 10),
-                            ],
-                            Padding(
-                              padding: const EdgeInsets.symmetric(horizontal: 18.0),
-                              child: Align(
-                                alignment: Alignment.centerLeft,
-                                child: Text(
-                                  context.l10n.login_header,
-                                  textAlign: TextAlign.left,
-                                  style: LoonoSizes.responsiveStyleScale(
-                                    context,
-                                    LoonoFonts.headerFontStyle,
-                                  ),
+                                      ),
+                                    );
+                                  },
+                                );
+                              },
+                              child: const Text('switch api (dev flavour only)'),
+                            ),
+                            const SizedBox(height: 10),
+                          ],
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 18.0),
+                            child: Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(
+                                context.l10n.login_header,
+                                textAlign: TextAlign.left,
+                                style: LoonoSizes.responsiveStyleScale(
+                                  context,
+                                  LoonoFonts.headerFontStyle,
                                 ),
                               ),
                             ),
-                            Expanded(child: SvgPicture.asset('assets/icons/carousel_doctors.svg')),
-                          ],
-                        ),
+                          ),
+                          Expanded(child: SvgPicture.asset('assets/icons/carousel_doctors.svg')),
+                        ],
                       ),
                     ),
-                    if (isScreenSmall) const SizedBox(height: 10),
-                    if (Platform.isIOS) ...[
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 18.0),
-                        child: SocialLoginButton.apple(
-                          onPressed: () async => _processSocialLogin(context,
-                              socialLoginMethod: SocialLoginMethod.apple),
-                        ),
-                      ),
-                      const SizedBox(height: 20.0),
-                    ],
+                  ),
+                  if (isScreenSmall) const SizedBox(height: 10),
+                  if (Platform.isIOS) ...[
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 18.0),
-                      child: SocialLoginButton.google(
-                        onPressed: () async => _processSocialLogin(context,
-                            socialLoginMethod: SocialLoginMethod.google),
+                      child: SocialLoginButton.apple(
+                        onPressed: () async => _processSocialLogin(
+                          context,
+                          socialLoginMethod: SocialLoginMethod.apple,
+                        ),
                       ),
                     ),
-                    if (!isScreenSmall) const SizedBox(height: 10),
-                    TextButton(
-                      onPressed: () async {
-                        final questionnaires = await _examinationQuestionnairesDao.getAll();
-                        if (questionnaires.isOnboardingDone) {
-                          await AutoRouter.of(context).push(PreAuthMainRoute());
-                        } else {
-                          await AutoRouter.of(context).push(const OnboardingWrapperRoute());
-                        }
-                      },
-                      child: Text(
-                        context.l10n.login_create_new_account,
-                        style: LoonoFonts.paragraphFontStyle,
-                      ),
-                    ),
-                    if (!isScreenSmall) const SizedBox(height: 10),
+                    const SizedBox(height: 20.0),
                   ],
-                ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 18.0),
+                    child: SocialLoginButton.google(
+                      onPressed: () async => _processSocialLogin(
+                        context,
+                        socialLoginMethod: SocialLoginMethod.google,
+                      ),
+                    ),
+                  ),
+                  if (!isScreenSmall) const SizedBox(height: 10),
+                  TextButton(
+                    onPressed: () async {
+                      final questionnaires = await _examinationQuestionnairesDao.getAll();
+                      if (questionnaires.isOnboardingDone) {
+                        await AutoRouter.of(context).push(PreAuthMainRoute());
+                      } else {
+                        await AutoRouter.of(context).push(const OnboardingWrapperRoute());
+                      }
+                    },
+                    child: Text(
+                      context.l10n.login_create_new_account,
+                      style: LoonoFonts.paragraphFontStyle,
+                    ),
+                  ),
+                  if (!isScreenSmall) const SizedBox(height: 10),
+                ],
               ),
             ),
-          );
-        });
+          ),
+        );
+      },
+    );
   }
 
   Future<void> _processSocialLogin(

--- a/lib/ui/screens/main/pre_auth/onboarding_form_done.dart
+++ b/lib/ui/screens/main/pre_auth/onboarding_form_done.dart
@@ -40,154 +40,157 @@ class OnboardingFormDoneScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final isScreenSmall = LoonoSizes.isScreenSmall(context);
     return ValueListenableBuilder<bool>(
-        valueListenable: _isLoading,
-        builder: (context, isLoadingValue, _) {
-          return ModalProgressHUD(
-            inAsyncCall: isLoadingValue,
-            progressIndicator: const CircularProgressIndicator(color: LoonoColors.primaryEnabled),
-            opacity: 0.5,
-            child: Scaffold(
-              body: SafeArea(
-                child: ListView(
-                  children: [
-                    Container(
-                      color: const Color.fromRGBO(237, 248, 253, 1),
-                      child: Padding(
-                        padding: const EdgeInsets.only(top: 0, left: 18, right: 18),
-                        child: Column(
-                          children: [
-                            const SizedBox(height: 10),
-                            SkipButton(
-                              text: context.l10n.already_have_an_account_skip_button,
-                              onPressed: () {
-                                if (AutoRouter.of(context).isRouteActive(PreAuthMainRoute.name)) {
-                                  AutoRouter.of(context).popUntilRoot();
-                                }
-                                AutoRouter.of(context).replaceAll([
-                                  const OnboardingWrapperRoute(),
-                                  LoginRoute(),
-                                  PreAuthMainRoute(overridenPreventionRoute: LoginRoute()),
-                                ]);
-                              },
+      valueListenable: _isLoading,
+      builder: (context, isLoadingValue, _) {
+        return ModalProgressHUD(
+          inAsyncCall: isLoadingValue,
+          progressIndicator: const CircularProgressIndicator(color: LoonoColors.primaryEnabled),
+          opacity: 0.5,
+          child: Scaffold(
+            body: SafeArea(
+              child: ListView(
+                children: [
+                  Container(
+                    color: const Color.fromRGBO(237, 248, 253, 1),
+                    child: Padding(
+                      padding: const EdgeInsets.only(top: 0, left: 18, right: 18),
+                      child: Column(
+                        children: [
+                          const SizedBox(height: 10),
+                          SkipButton(
+                            text: context.l10n.already_have_an_account_skip_button,
+                            onPressed: () {
+                              if (AutoRouter.of(context).isRouteActive(PreAuthMainRoute.name)) {
+                                AutoRouter.of(context).popUntilRoot();
+                              }
+                              AutoRouter.of(context).replaceAll([
+                                const OnboardingWrapperRoute(),
+                                LoginRoute(),
+                                PreAuthMainRoute(overridenPreventionRoute: LoginRoute()),
+                              ]);
+                            },
+                          ),
+                          SizedBox(height: isScreenSmall ? 6 : 24),
+                          Text(
+                            context.l10n.onboarding_form_done_header,
+                            textAlign: TextAlign.start,
+                            style: LoonoSizes.responsiveStyleScale(
+                              context,
+                              LoonoFonts.headerFontStyle,
                             ),
-                            SizedBox(height: isScreenSmall ? 6 : 24),
-                            Text(
-                              context.l10n.onboarding_form_done_header,
-                              textAlign: TextAlign.start,
-                              style: LoonoSizes.responsiveStyleScale(
-                                  context, LoonoFonts.headerFontStyle),
-                            ),
-                            Row(
-                              children: [
-                                Flexible(
-                                  child: Row(
-                                    children: [
-                                      SvgPicture.asset(
-                                        'assets/icons/prevention/success_checkmark.svg',
-                                        width: 30,
-                                      ),
-                                      const SizedBox(width: 10),
-                                      Flexible(
-                                        child: Text(
-                                          context.l10n.onboarding_form_done_success_message,
-                                          textAlign: TextAlign.start,
-                                          style: LoonoFonts.subtitleFontStyle.copyWith(
-                                            color: LoonoColors.greenSuccess,
-                                          ),
+                          ),
+                          Row(
+                            children: [
+                              Flexible(
+                                child: Row(
+                                  children: [
+                                    SvgPicture.asset(
+                                      'assets/icons/prevention/success_checkmark.svg',
+                                      width: 30,
+                                    ),
+                                    const SizedBox(width: 10),
+                                    Flexible(
+                                      child: Text(
+                                        context.l10n.onboarding_form_done_success_message,
+                                        textAlign: TextAlign.start,
+                                        style: LoonoFonts.subtitleFontStyle.copyWith(
+                                          color: LoonoColors.greenSuccess,
                                         ),
                                       ),
-                                    ],
-                                  ),
-                                ),
-                                Align(
-                                  alignment: Alignment.centerRight,
-                                  child: Padding(
-                                    padding: const EdgeInsets.only(right: 8.0),
-                                    child: SvgPicture.asset(
-                                      'assets/icons/doctor_finish_questionnaire.svg',
-                                      width: isScreenSmall ? 90 : null,
                                     ),
+                                  ],
+                                ),
+                              ),
+                              Align(
+                                alignment: Alignment.centerRight,
+                                child: Padding(
+                                  padding: const EdgeInsets.only(right: 8.0),
+                                  child: SvgPicture.asset(
+                                    'assets/icons/doctor_finish_questionnaire.svg',
+                                    width: isScreenSmall ? 90 : null,
                                   ),
                                 ),
-                              ],
-                            ),
-                          ],
-                        ),
-                      ),
-                    ),
-                    SizedBox(height: isScreenSmall ? 5 : 30),
-                    if (Platform.isIOS)
-                      Padding(
-                        padding: const EdgeInsets.only(left: 18, right: 18),
-                        child: SocialLoginButton.apple(
-                          onPressed: () async => _processSocialAuth(
-                            context,
-                            socialLoginMethod: SocialLoginMethod.apple,
-                          ),
-                        ),
-                      ),
-                    const SizedBox(height: 20),
-                    Padding(
-                      padding: const EdgeInsets.only(left: 18, right: 18),
-                      child: SocialLoginButton.google(
-                        key: const Key('onboardingFormDonePage_btn_googleSignUp'),
-                        onPressed: () async => _processSocialAuth(
-                          context,
-                          socialLoginMethod: SocialLoginMethod.google,
-                        ),
-                      ),
-                    ),
-                    SizedBox(height: isScreenSmall ? 5 : 20),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 28.0),
-                      child: TextButton(
-                        onPressed: () => debugPrint('open'),
-                        child: Text.rich(
-                          TextSpan(
-                            text: context.l10n.by_logging_in_you_agree_to_the_terms_of_privacy,
-                            children: [
-                              TextSpan(
-                                text: context.l10n.by_logging_in_you_agree_to_the_terms_highlight,
-                                style: LoonoFonts.fontStyle
-                                    .copyWith(decoration: TextDecoration.underline),
-                                recognizer: TapGestureRecognizer()
-                                  ..onTap = () async {
-                                    if (await canLaunch(termsUrl)) {
-                                      await launch(
-                                        termsUrl,
-                                      );
-                                    }
-                                  },
-                              ),
-                              TextSpan(
-                                text: ' ${context.l10n.examination_detail_rewards_get_badge_2} ',
-                              ),
-                              TextSpan(
-                                text: context.l10n.by_logging_in_you_agree_to_the_privacy_highlight,
-                                style: LoonoFonts.fontStyle
-                                    .copyWith(decoration: TextDecoration.underline),
-                                recognizer: TapGestureRecognizer()
-                                  ..onTap = () async {
-                                    if (await canLaunch(privacyUrl)) {
-                                      await launch(
-                                        privacyUrl,
-                                      );
-                                    }
-                                  },
                               ),
                             ],
                           ),
-                          style: LoonoFonts.fontStyle.copyWith(fontSize: 12),
-                          textAlign: TextAlign.center,
+                        ],
+                      ),
+                    ),
+                  ),
+                  SizedBox(height: isScreenSmall ? 5 : 30),
+                  if (Platform.isIOS)
+                    Padding(
+                      padding: const EdgeInsets.only(left: 18, right: 18),
+                      child: SocialLoginButton.apple(
+                        onPressed: () async => _processSocialAuth(
+                          context,
+                          socialLoginMethod: SocialLoginMethod.apple,
                         ),
                       ),
                     ),
-                  ],
-                ),
+                  const SizedBox(height: 20),
+                  Padding(
+                    padding: const EdgeInsets.only(left: 18, right: 18),
+                    child: SocialLoginButton.google(
+                      key: const Key('onboardingFormDonePage_btn_googleSignUp'),
+                      onPressed: () async => _processSocialAuth(
+                        context,
+                        socialLoginMethod: SocialLoginMethod.google,
+                      ),
+                    ),
+                  ),
+                  SizedBox(height: isScreenSmall ? 5 : 20),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 28.0),
+                    child: TextButton(
+                      onPressed: () => debugPrint('open'),
+                      child: Text.rich(
+                        TextSpan(
+                          text: context.l10n.by_logging_in_you_agree_to_the_terms_of_privacy,
+                          children: [
+                            TextSpan(
+                              text: context.l10n.by_logging_in_you_agree_to_the_terms_highlight,
+                              style: LoonoFonts.fontStyle
+                                  .copyWith(decoration: TextDecoration.underline),
+                              recognizer: TapGestureRecognizer()
+                                ..onTap = () async {
+                                  if (await canLaunch(termsUrl)) {
+                                    await launch(
+                                      termsUrl,
+                                    );
+                                  }
+                                },
+                            ),
+                            TextSpan(
+                              text: ' ${context.l10n.examination_detail_rewards_get_badge_2} ',
+                            ),
+                            TextSpan(
+                              text: context.l10n.by_logging_in_you_agree_to_the_privacy_highlight,
+                              style: LoonoFonts.fontStyle
+                                  .copyWith(decoration: TextDecoration.underline),
+                              recognizer: TapGestureRecognizer()
+                                ..onTap = () async {
+                                  if (await canLaunch(privacyUrl)) {
+                                    await launch(
+                                      privacyUrl,
+                                    );
+                                  }
+                                },
+                            ),
+                          ],
+                        ),
+                        style: LoonoFonts.fontStyle.copyWith(fontSize: 12),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
-          );
-        });
+          ),
+        );
+      },
+    );
   }
 
   Future<void> _processSocialAuth(

--- a/lib/ui/screens/main/pre_auth/onboarding_form_done.dart
+++ b/lib/ui/screens/main/pre_auth/onboarding_form_done.dart
@@ -15,9 +15,12 @@ import 'package:loono/repositories/user_repository.dart';
 import 'package:loono/router/app_router.gr.dart';
 import 'package:loono/services/auth/auth_service.dart';
 import 'package:loono/services/auth/failures.dart';
+import 'package:loono/services/examinations_service.dart';
 import 'package:loono/ui/widgets/skip_button.dart';
 import 'package:loono/ui/widgets/social_login_button.dart';
 import 'package:loono/utils/registry.dart';
+import 'package:modal_progress_hud_nsn/modal_progress_hud_nsn.dart';
+import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class OnboardingFormDoneScreen extends StatelessWidget {
@@ -29,146 +32,162 @@ class OnboardingFormDoneScreen extends StatelessWidget {
   final termsUrl = 'https://www.loono.cz/podminky-uzivani-mobilni-aplikace';
   final privacyUrl = 'https://www.loono.cz/zasady-ochrany-osobnich-udaju-mobilni-aplikace';
 
+  final ValueNotifier<bool> _isLoading = ValueNotifier(false);
+
+  void _setLoadingState(bool value) => _isLoading.value = value;
+
   @override
   Widget build(BuildContext context) {
     final isScreenSmall = LoonoSizes.isScreenSmall(context);
-    return Scaffold(
-      body: SafeArea(
-        child: ListView(
-          children: [
-            Container(
-              color: const Color.fromRGBO(237, 248, 253, 1),
-              child: Padding(
-                padding: const EdgeInsets.only(top: 0, left: 18, right: 18),
-                child: Column(
+    return ValueListenableBuilder<bool>(
+        valueListenable: _isLoading,
+        builder: (context, isLoadingValue, _) {
+          return ModalProgressHUD(
+            inAsyncCall: isLoadingValue,
+            progressIndicator: const CircularProgressIndicator(color: LoonoColors.primaryEnabled),
+            opacity: 0.5,
+            child: Scaffold(
+              body: SafeArea(
+                child: ListView(
                   children: [
-                    const SizedBox(height: 10),
-                    SkipButton(
-                      text: context.l10n.already_have_an_account_skip_button,
-                      onPressed: () {
-                        if (AutoRouter.of(context).isRouteActive(PreAuthMainRoute.name)) {
-                          AutoRouter.of(context).popUntilRoot();
-                        }
-                        AutoRouter.of(context).replaceAll([
-                          const OnboardingWrapperRoute(),
-                          LoginRoute(),
-                          PreAuthMainRoute(overridenPreventionRoute: LoginRoute()),
-                        ]);
-                      },
-                    ),
-                    SizedBox(height: isScreenSmall ? 6 : 24),
-                    Text(
-                      context.l10n.onboarding_form_done_header,
-                      textAlign: TextAlign.start,
-                      style: LoonoSizes.responsiveStyleScale(context, LoonoFonts.headerFontStyle),
-                    ),
-                    Row(
-                      children: [
-                        Flexible(
-                          child: Row(
-                            children: [
-                              SvgPicture.asset(
-                                'assets/icons/prevention/success_checkmark.svg',
-                                width: 30,
-                              ),
-                              const SizedBox(width: 10),
-                              Flexible(
-                                child: Text(
-                                  context.l10n.onboarding_form_done_success_message,
-                                  textAlign: TextAlign.start,
-                                  style: LoonoFonts.subtitleFontStyle.copyWith(
-                                    color: LoonoColors.greenSuccess,
+                    Container(
+                      color: const Color.fromRGBO(237, 248, 253, 1),
+                      child: Padding(
+                        padding: const EdgeInsets.only(top: 0, left: 18, right: 18),
+                        child: Column(
+                          children: [
+                            const SizedBox(height: 10),
+                            SkipButton(
+                              text: context.l10n.already_have_an_account_skip_button,
+                              onPressed: () {
+                                if (AutoRouter.of(context).isRouteActive(PreAuthMainRoute.name)) {
+                                  AutoRouter.of(context).popUntilRoot();
+                                }
+                                AutoRouter.of(context).replaceAll([
+                                  const OnboardingWrapperRoute(),
+                                  LoginRoute(),
+                                  PreAuthMainRoute(overridenPreventionRoute: LoginRoute()),
+                                ]);
+                              },
+                            ),
+                            SizedBox(height: isScreenSmall ? 6 : 24),
+                            Text(
+                              context.l10n.onboarding_form_done_header,
+                              textAlign: TextAlign.start,
+                              style: LoonoSizes.responsiveStyleScale(
+                                  context, LoonoFonts.headerFontStyle),
+                            ),
+                            Row(
+                              children: [
+                                Flexible(
+                                  child: Row(
+                                    children: [
+                                      SvgPicture.asset(
+                                        'assets/icons/prevention/success_checkmark.svg',
+                                        width: 30,
+                                      ),
+                                      const SizedBox(width: 10),
+                                      Flexible(
+                                        child: Text(
+                                          context.l10n.onboarding_form_done_success_message,
+                                          textAlign: TextAlign.start,
+                                          style: LoonoFonts.subtitleFontStyle.copyWith(
+                                            color: LoonoColors.greenSuccess,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
                                   ),
                                 ),
+                                Align(
+                                  alignment: Alignment.centerRight,
+                                  child: Padding(
+                                    padding: const EdgeInsets.only(right: 8.0),
+                                    child: SvgPicture.asset(
+                                      'assets/icons/doctor_finish_questionnaire.svg',
+                                      width: isScreenSmall ? 90 : null,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: isScreenSmall ? 5 : 30),
+                    if (Platform.isIOS)
+                      Padding(
+                        padding: const EdgeInsets.only(left: 18, right: 18),
+                        child: SocialLoginButton.apple(
+                          onPressed: () async => _processSocialAuth(
+                            context,
+                            socialLoginMethod: SocialLoginMethod.apple,
+                          ),
+                        ),
+                      ),
+                    const SizedBox(height: 20),
+                    Padding(
+                      padding: const EdgeInsets.only(left: 18, right: 18),
+                      child: SocialLoginButton.google(
+                        key: const Key('onboardingFormDonePage_btn_googleSignUp'),
+                        onPressed: () async => _processSocialAuth(
+                          context,
+                          socialLoginMethod: SocialLoginMethod.google,
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: isScreenSmall ? 5 : 20),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 28.0),
+                      child: TextButton(
+                        onPressed: () => debugPrint('open'),
+                        child: Text.rich(
+                          TextSpan(
+                            text: context.l10n.by_logging_in_you_agree_to_the_terms_of_privacy,
+                            children: [
+                              TextSpan(
+                                text: context.l10n.by_logging_in_you_agree_to_the_terms_highlight,
+                                style: LoonoFonts.fontStyle
+                                    .copyWith(decoration: TextDecoration.underline),
+                                recognizer: TapGestureRecognizer()
+                                  ..onTap = () async {
+                                    if (await canLaunch(termsUrl)) {
+                                      await launch(
+                                        termsUrl,
+                                      );
+                                    }
+                                  },
+                              ),
+                              TextSpan(
+                                text: ' ${context.l10n.examination_detail_rewards_get_badge_2} ',
+                              ),
+                              TextSpan(
+                                text: context.l10n.by_logging_in_you_agree_to_the_privacy_highlight,
+                                style: LoonoFonts.fontStyle
+                                    .copyWith(decoration: TextDecoration.underline),
+                                recognizer: TapGestureRecognizer()
+                                  ..onTap = () async {
+                                    if (await canLaunch(privacyUrl)) {
+                                      await launch(
+                                        privacyUrl,
+                                      );
+                                    }
+                                  },
                               ),
                             ],
                           ),
+                          style: LoonoFonts.fontStyle.copyWith(fontSize: 12),
+                          textAlign: TextAlign.center,
                         ),
-                        Align(
-                          alignment: Alignment.centerRight,
-                          child: Padding(
-                            padding: const EdgeInsets.only(right: 8.0),
-                            child: SvgPicture.asset(
-                              'assets/icons/doctor_finish_questionnaire.svg',
-                              width: isScreenSmall ? 90 : null,
-                            ),
-                          ),
-                        ),
-                      ],
+                      ),
                     ),
                   ],
                 ),
               ),
             ),
-            SizedBox(height: isScreenSmall ? 5 : 30),
-            if (Platform.isIOS)
-              Padding(
-                padding: const EdgeInsets.only(left: 18, right: 18),
-                child: SocialLoginButton.apple(
-                  onPressed: () async => _processSocialAuth(
-                    context,
-                    socialLoginMethod: SocialLoginMethod.apple,
-                  ),
-                ),
-              ),
-            const SizedBox(height: 20),
-            Padding(
-              padding: const EdgeInsets.only(left: 18, right: 18),
-              child: SocialLoginButton.google(
-                key: const Key('onboardingFormDonePage_btn_googleSignUp'),
-                onPressed: () async => _processSocialAuth(
-                  context,
-                  socialLoginMethod: SocialLoginMethod.google,
-                ),
-              ),
-            ),
-            SizedBox(height: isScreenSmall ? 5 : 20),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 28.0),
-              child: TextButton(
-                onPressed: () => debugPrint('open'),
-                child: Text.rich(
-                  TextSpan(
-                    text: context.l10n.by_logging_in_you_agree_to_the_terms_of_privacy,
-                    children: [
-                      TextSpan(
-                        text: context.l10n.by_logging_in_you_agree_to_the_terms_highlight,
-                        style: LoonoFonts.fontStyle.copyWith(decoration: TextDecoration.underline),
-                        recognizer: TapGestureRecognizer()
-                          ..onTap = () async {
-                            if (await canLaunch(termsUrl)) {
-                              await launch(
-                                termsUrl,
-                              );
-                            }
-                          },
-                      ),
-                      TextSpan(
-                        text: ' ${context.l10n.examination_detail_rewards_get_badge_2} ',
-                      ),
-                      TextSpan(
-                        text: context.l10n.by_logging_in_you_agree_to_the_privacy_highlight,
-                        style: LoonoFonts.fontStyle.copyWith(decoration: TextDecoration.underline),
-                        recognizer: TapGestureRecognizer()
-                          ..onTap = () async {
-                            if (await canLaunch(privacyUrl)) {
-                              await launch(
-                                privacyUrl,
-                              );
-                            }
-                          },
-                      ),
-                    ],
-                  ),
-                  style: LoonoFonts.fontStyle.copyWith(fontSize: 12),
-                  textAlign: TextAlign.center,
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
+          );
+        });
   }
 
   Future<void> _processSocialAuth(
@@ -191,7 +210,7 @@ class OnboardingFormDoneScreen extends StatelessWidget {
         break;
     }
     await accountExistsResult.fold(
-      (failure) async {
+      (failure) {
         failure.maybeWhen(
           accountNotExists: (socialAccount) =>
               AutoRouter.of(context).push(NicknameRoute(socialLoginAccount: socialAccount)),
@@ -199,9 +218,21 @@ class OnboardingFormDoneScreen extends StatelessWidget {
         );
       },
       (authUser) async {
-        // email already has an existing account, login
-        await _userRepository.createUser();
-        await AutoRouter.of(context).replaceAll([const MainScreenRouter()]);
+        _setLoadingState(true);
+        await context.read<ExaminationsProvider>().fetchExaminations().then(
+              (res) async => res.when(
+                success: (data) async {
+                  // An account with this email already exists, proceed through the login.
+                  await _userRepository.createUser();
+                  await AutoRouter.of(context).replaceAll([const MainScreenRouter()]);
+                },
+                failure: (_) async {
+                  showFlushBarError(context, context.l10n.login_server_down_message);
+                  await _authService.signOut();
+                },
+              ),
+            );
+        _setLoadingState(false);
       },
     );
   }

--- a/lib/ui/screens/onboarding/fallback_account/email.dart
+++ b/lib/ui/screens/onboarding/fallback_account/email.dart
@@ -81,8 +81,8 @@ class EmailScreen extends StatelessWidget {
                   },
                   failure: (_) async {
                     // delete account so user can not login without saving info to server first
-                    await authUser.delete();
                     showFlushBarError(context, context.l10n.something_went_wrong);
+                    await authUser.delete();
                   },
                 );
               },

--- a/lib/utils/registry.dart
+++ b/lib/utils/registry.dart
@@ -8,7 +8,6 @@ import 'package:device_info_plus/device_info_plus.dart';
 import 'package:dio/dio.dart';
 import 'package:dio_smart_retry/dio_smart_retry.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
@@ -18,7 +17,6 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:get_it/get_it.dart';
-import 'package:google_sign_in/google_sign_in.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:loono/repositories/calendar_repository.dart';
 import 'package:loono/repositories/examination_repository.dart';
@@ -50,8 +48,6 @@ const FORCE_UPDATE_STATUS_CODE = 410;
 
 Future<void> setup({
   Dio? dioOverride,
-  GoogleSignIn? googleSignIn,
-  FirebaseAuth? firebaseAuth,
   Map<String, String>? envOverride,
   required AppFlavors flavor,
 }) async {
@@ -180,8 +176,6 @@ Future<void> setup({
   registry.registerSingleton<AuthService>(
     AuthService(
       api: registry.get<LoonoApi>(),
-      firebaseAuth: firebaseAuth ?? FirebaseAuth.instance,
-      googleSignIn: googleSignIn ?? GoogleSignIn(),
       secureStorageService: registry.get<SecureStorageService>(),
     ),
   );


### PR DESCRIPTION
pokud existuje účet, po přihlášení přes Google/Apple přes Firebase se ještě provolá `GET /examinations`, zda-li funguje backend. Pokud nastane error, vyhodí se hláška o nedostupnosti serveru. @MartinMacek je toto za tebe ok přístup? moc mě nenapadlo jak jinak na to když máme prakticky 2 služby... Případně jestli volat jiný endpoint.

spojil jsem to ještě s přidáním testu + clean upy (smazáno passování FirebaseAuth, které vlastně nebylo třeba - toto se již mockuje přes Platform Channely)

https://cesko-digital.atlassian.net/browse/LOON-627