### PR TITLE
fix(api): send not shifted UTC date

### DIFF
--- a/lib/helpers/date_helpers.dart
+++ b/lib/helpers/date_helpers.dart
@@ -5,19 +5,3 @@ int daysBetween(DateTime from, DateTime to) {
   /// .inDays does not work here (https://stackoverflow.com/questions/52713115/flutter-find-the-number-of-days-between-two-dates/67679455#67679455)
   return (to.difference(from).inHours / 24).round();
 }
-
-/// Server does not seem to handle the UTC ?
-DateTime? getFakeUtcDate(DateTime? dateTime) {
-  DateTime? fakeUtcNewDate;
-  if (dateTime != null) {
-    fakeUtcNewDate = DateTime.utc(
-      dateTime.year,
-      dateTime.month,
-      dateTime.day,
-      dateTime.hour,
-      dateTime.minute,
-      dateTime.second,
-    );
-  }
-  return fakeUtcNewDate;
-}

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -128,25 +128,13 @@ class ApiService {
     ExaminationStatus? status,
     bool? firstExam,
   }) async {
-    DateTime? utcNewDate;
-    if (newDate != null) {
-      utcNewDate = DateTime.utc(
-        newDate.year,
-        newDate.month,
-        newDate.day,
-        newDate.hour,
-        newDate.minute,
-        newDate.second,
-      );
-    }
-
     return _callApi(
       () async => _api.getExaminationsApi().postExaminations(
         examinationRecord: ExaminationRecord((record) {
           record
             ..uuid = uuid
             ..type = type
-            ..plannedDate = utcNewDate
+            ..plannedDate = newDate?.toUtc()
             ..status = status
             ..firstExam = firstExam;
         }),

--- a/lib/ui/screens/onboarding/fallback_account/email.dart
+++ b/lib/ui/screens/onboarding/fallback_account/email.dart
@@ -5,7 +5,6 @@ import 'package:built_collection/built_collection.dart';
 import 'package:dartz/dartz.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:loono/helpers/date_helpers.dart';
 import 'package:loono/helpers/flushbar_message.dart';
 import 'package:loono/helpers/nickname_hint_resolver.dart';
 import 'package:loono/helpers/onboarding_state_helpers.dart';
@@ -120,7 +119,7 @@ class EmailScreen extends StatelessWidget {
             ExaminationRecord((b) {
               b
                 ..status = questionnaire.status
-                ..plannedDate = getFakeUtcDate(questionnaire.date)
+                ..plannedDate = questionnaire.date?.toUtc()
                 ..firstExam = true
                 ..type = questionnaire.type;
             })


### PR DESCRIPTION
tedkom se teda posílá se pravý (neshiftnutý na local) UTC date
[BE test](https://github.com/cesko-digital/loono/runs/6377510558?check_suite_focus=true) prošel